### PR TITLE
設定画面・パスキー管理画面のUI改善

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -11,6 +11,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class ConfigController extends AbstractController
 {
+    private const BASE_DOMAIN = '.ec-auth.io';
+
     /**
      * @var ConfigRepository
      */
@@ -28,11 +30,24 @@ class ConfigController extends AbstractController
     public function index(Request $request)
     {
         $Config = $this->configRepository->get();
+        $hasClientSecret = $Config && $Config->getClientSecret() !== null && $Config->getClientSecret() !== '';
+
+        // DB のフル URL からサブドメイン部分を抽出してフォームにセット
+        $subdomain = $this->extractSubdomain($Config ? $Config->getEcauthBaseUrl() : null);
+        if ($subdomain !== null) {
+            $Config->setEcauthBaseUrl($subdomain);
+        }
+
         $form = $this->createForm(ConfigType::class, $Config);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $Config = $form->getData();
+
+            // サブドメインをフル URL に変換して保存
+            $inputSubdomain = $Config->getEcauthBaseUrl();
+            $Config->setEcauthBaseUrl('https://' . $inputSubdomain . self::BASE_DOMAIN);
+
             $clientSecret = $form->get('client_secret')->getData();
             if ($clientSecret !== null && $clientSecret !== '') {
                 $Config->setClientSecret($clientSecret);
@@ -47,6 +62,22 @@ class ConfigController extends AbstractController
 
         return [
             'form' => $form->createView(),
+            'has_client_secret' => $hasClientSecret,
         ];
+    }
+
+    private function extractSubdomain(?string $baseUrl): ?string
+    {
+        if ($baseUrl === null || $baseUrl === '') {
+            return null;
+        }
+
+        // https://{subdomain}.ec-auth.io からサブドメインを抽出
+        $pattern = '#^https?://(.+)' . preg_quote(self::BASE_DOMAIN, '#') . '/?$#';
+        if (preg_match($pattern, $baseUrl, $matches)) {
+            return $matches[1];
+        }
+
+        return null;
     }
 }

--- a/Form/Type/Admin/ConfigType.php
+++ b/Form/Type/Admin/ConfigType.php
@@ -6,7 +6,6 @@ use Plugin\EcAuthLogin43\Entity\Config;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\UrlType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
@@ -16,7 +15,7 @@ class ConfigType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('ecauth_base_url', UrlType::class, [
+            ->add('ecauth_base_url', TextType::class, [
                 'constraints' => [
                     new NotBlank(),
                 ],

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -2,7 +2,8 @@
 ecauth_login43.admin.config.title: EcAuth 設定
 ecauth_login43.admin.config.sub_title: プラグイン設定
 ecauth_login43.admin.config.header: EcAuth 接続設定
-ecauth_login43.admin.config.ecauth_base_url: EcAuth Base URL
+ecauth_login43.admin.config.ecauth_base_url: Organization Code
+ecauth_login43.admin.config.ecauth_base_url.help: EcAuth のサブドメイン（Organization Code）を入力してください。
 ecauth_login43.admin.config.client_id: Client ID
 ecauth_login43.admin.config.client_secret: Client Secret
 ecauth_login43.admin.config.rp_id: RP ID

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -24,8 +24,17 @@
                                     <span class="badge badge-primary ml-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
                                 </div>
                                 <div class="col">
-                                    {{ form_widget(form.ecauth_base_url) }}
+                                    <div class="input-group">
+                                        <div class="input-group-prepend">
+                                            <span class="input-group-text">https://</span>
+                                        </div>
+                                        {{ form_widget(form.ecauth_base_url) }}
+                                        <div class="input-group-append">
+                                            <span class="input-group-text">.ec-auth.io</span>
+                                        </div>
+                                    </div>
                                     {{ form_errors(form.ecauth_base_url) }}
+                                    <p class="form-text text-muted">{{ 'ecauth_login43.admin.config.ecauth_base_url.help'|trans }}</p>
                                 </div>
                             </div>
                             <div class="row mb-2">
@@ -44,7 +53,7 @@
                                     <span class="badge badge-primary ml-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
                                 </div>
                                 <div class="col">
-                                    {{ form_widget(form.client_secret) }}
+                                    {{ form_widget(form.client_secret, { attr: has_client_secret ? { placeholder: '••••••••••••••••' } : {} }) }}
                                     {{ form_errors(form.client_secret) }}
                                 </div>
                             </div>

--- a/Resource/template/admin/passkey_list.twig
+++ b/Resource/template/admin/passkey_list.twig
@@ -143,7 +143,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 <div class="card rounded border-0 mb-4">
                     <div class="card-header d-flex justify-content-between align-items-center">
                         <span>{{ 'ecauth_login43.admin.passkey.header'|trans }}</span>
-                        <button type="button" id="ecauth-passkey-add" class="btn btn-ec-regular btn-sm">
+                        <button type="button" id="ecauth-passkey-add" class="btn btn-ec-regular">
                             <i class="fa fa-plus mr-1"></i>{{ 'ecauth_login43.admin.passkey.add'|trans }}
                         </button>
                     </div>


### PR DESCRIPTION
## Summary
- EcAuth Base URL を Organization Code（サブドメイン）のみの入力に変更し、`https://` プレフィックスと `.ec-auth.io` サフィックスを input-group で表示
- Client Secret が登録済みの場合、placeholder にマスク文字列（••••••••••••••••）を表示して登録状態を明示
- パスキー追加ボタンから `btn-sm` を削除してボタンサイズを拡大

## Test plan
- [ ] EcAuth 設定画面で Organization Code のみ入力して保存し、DBにフルURL（`https://{code}.ec-auth.io`）が保存されることを確認
- [ ] 設定画面再読み込み後、サブドメインのみが入力欄に表示されることを確認
- [ ] Client Secret 登録済み状態で設定画面を開き、placeholder に `••••••••••••••••` が表示されることを確認
- [ ] パスキー管理画面で「パスキーを追加」ボタンが通常サイズで表示されることを確認
- [ ] E2E テスト: `pnpm exec playwright test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **UI改善**
  * Organization Code設定フィールドが`https://[code].ec-auth.io`形式を表示するように更新
  * Organization Code入力のヘルプテキストを追加
  * 「パスキー追加」ボタンのサイズを調整

* **その他の改善**
  * クライアント認証情報の表示処理を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->