### PR TITLE
feat: CDN 配信への移行 - script src を cdn.ec-auth.io に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,13 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Build JS assets
+      - name: Pin auth-js version in services.yaml
         run: |
           corepack enable
           pnpm install --frozen-lockfile
-          pnpm run build:js
+          AUTH_JS_VERSION=$(node -e "console.log(require('./node_modules/@ecauth/auth-js/package.json').version)")
+          echo "Pinning @ecauth/auth-js version to ${AUTH_JS_VERSION}"
+          sed -i "s/ecauth_auth_js_version: 'latest'/ecauth_auth_js_version: '${AUTH_JS_VERSION}'/" Resource/config/services.yaml
 
       - name: Packaging
         working-directory: ../

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@
 /test-results/
 /playwright-report/
 /.env
-/Resource/assets/js/ecauth-auth.umd.js

--- a/Controller/Admin/PasskeyController.php
+++ b/Controller/Admin/PasskeyController.php
@@ -22,12 +22,19 @@ class PasskeyController extends AbstractController
      */
     private $passkeyAuthService;
 
+    /**
+     * @var string
+     */
+    private $authJsVersion;
+
     public function __construct(
         EcAuthApiClient $apiClient,
         PasskeyAuthService $passkeyAuthService,
+        string $ecauth_auth_js_version,
     ) {
         $this->apiClient = $apiClient;
         $this->passkeyAuthService = $passkeyAuthService;
+        $this->authJsVersion = $ecauth_auth_js_version;
     }
 
     /**
@@ -56,6 +63,7 @@ class PasskeyController extends AbstractController
         return [
             'passkeys' => $passkeys,
             'error' => $error,
+            'ecauth_auth_js_version' => $this->authJsVersion,
         ];
     }
 

--- a/EcAuthLoginEvent.php
+++ b/EcAuthLoginEvent.php
@@ -8,6 +8,16 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 class EcAuthLoginEvent implements EventSubscriberInterface
 {
     /**
+     * @var string
+     */
+    private $authJsVersion;
+
+    public function __construct(string $ecauth_auth_js_version)
+    {
+        $this->authJsVersion = $ecauth_auth_js_version;
+    }
+
+    /**
      * @return array
      */
     public static function getSubscribedEvents()
@@ -19,6 +29,7 @@ class EcAuthLoginEvent implements EventSubscriberInterface
 
     public function onAdminLoginTwig(TemplateEvent $event)
     {
+        $event->setParameter('ecauth_auth_js_version', $this->authJsVersion);
         // login_frame.twig は plugin_snippets を描画しないため、
         // addSnippet() ではなく setSource() でテンプレートソースに直接変更する。
         // login.twig は {% block javascript %} を定義していないので、追加する。

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -7,6 +7,8 @@ services:
         exclude: '../../{Entity,Resource,Tests,tests}'
         autowire: true
         autoconfigure: true
+        bind:
+            $ecauth_auth_js_version: '%ecauth_auth_js_version%'
 
 eccube:
     rate_limiter:

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,3 +1,6 @@
+parameters:
+    ecauth_auth_js_version: 'latest'
+
 services:
     Plugin\EcAuthLogin43\:
         resource: '../../*'

--- a/Resource/template/admin/login_passkey.twig
+++ b/Resource/template/admin/login_passkey.twig
@@ -1,4 +1,4 @@
-<script src="{{ asset('EcAuthLogin43/assets/js/ecauth-auth.umd.js', 'plugin') }}"></script>
+<script src="https://cdn.ec-auth.io/auth-js/{{ ecauth_auth_js_version }}/ecauth-auth.umd.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     // HTTPS かつ WebAuthn 対応時のみ表示

--- a/Resource/template/admin/passkey_list.twig
+++ b/Resource/template/admin/passkey_list.twig
@@ -39,7 +39,7 @@
 {% endblock %}
 
 {% block javascript %}
-<script src="{{ asset('EcAuthLogin43/assets/js/ecauth-auth.umd.js', 'plugin') }}"></script>
+<script src="https://cdn.ec-auth.io/auth-js/{{ ecauth_auth_js_version }}/ecauth-auth.umd.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     var addBtn = document.getElementById('ecauth-passkey-add');

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -46,12 +46,5 @@ else
     echo "EcAuthLogin43 plugin already installed."
 fi
 
-# プラグインアセットのシンボリックリンクを作成
-if [ -d /var/www/html/app/Plugin/EcAuthLogin43/Resource/assets ] && [ ! -L /var/www/html/html/plugin/EcAuthLogin43/assets ]; then
-    mkdir -p /var/www/html/html/plugin/EcAuthLogin43
-    ln -sfn /var/www/html/app/Plugin/EcAuthLogin43/Resource/assets /var/www/html/html/plugin/EcAuthLogin43/assets
-    echo "Plugin assets symlinked."
-fi
-
 # Apache 起動
 exec "$@"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ec-cube4-ecauth",
   "private": true,
   "scripts": {
-    "build:js": "cp node_modules/@ecauth/auth-js/dist/ecauth-auth.umd.js Resource/assets/js/ecauth-auth.umd.js",
     "test": "playwright test",
     "test:headed": "playwright test --headed"
   },


### PR DESCRIPTION
## Summary

- `@ecauth/auth-js` の UMD ファイルをプラグイン同梱（`build:js`）から CDN 配信（`cdn.ec-auth.io`）に移行
- `composer require` でインストールした場合に UMD ファイルが `html/plugin/` に配置されない問題を解決
- 開発時は `latest` を使用し、リリースパッケージング時に resolved バージョンを自動ピン留め

## Changes

- テンプレート（`login_passkey.twig`, `passkey_list.twig`）の `asset()` を CDN URL に変更
- `services.yaml` に `ecauth_auth_js_version` パラメータ追加（デフォルト: `latest`）
- `EcAuthLoginEvent` / `PasskeyController` にバージョンパラメータを注入しテンプレートに渡す
- `deploy.yml` でリリース時に `@ecauth/auth-js` の resolved バージョンを `services.yaml` に書き込み
- `build:js` スクリプト削除（`@ecauth/auth-js` devDependency はバージョン参照用に残す）
- `docker-entrypoint.sh` からアセットシンボリックリンク作成を削除
- `.gitignore` から `/Resource/assets/js/ecauth-auth.umd.js` エントリを削除

## Test plan

- [x] E2E テスト通過
- [x] 管理画面ログイン画面でパスキーボタンが表示されること（HTTPS 環境）
- [x] パスキー管理画面で JS が正常に読み込まれること
- [x] DevTools Network タブで `cdn.ec-auth.io` から JS がロードされていること
- [x] 417tea.cafe で動作確認

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * パスキー認証ライブラリをCDN配信に切り替えました。
  * インストール済みパッケージから認証ライブラリのバージョンを自動取得して設定に反映します。
  * 管理画面のパスキーログイン／一覧テンプレートがバージョン付きCDN URLのライブラリを参照するよう更新しました。
  * ローカルビルドスクリプトとアセットの自動リンク管理、関連のDocker処理を削除しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->