### PR TITLE
feat: EcAuth APIパスを /v1 プレフィックスに更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,13 +92,13 @@ ec-cube4-ecauth/
 
 | エンドポイント | 認証方式 | 用途 |
 |----------------|----------|------|
-| `POST /b2b/passkey/authenticate/options` | client_id | チャレンジ取得 |
-| `POST /b2b/passkey/authenticate/verify` | client_id | 署名検証→認可コード |
-| `POST /b2b/passkey/register/options` | client_id + client_secret | 登録オプション |
-| `POST /b2b/passkey/register/verify` | client_id + client_secret | 登録完了 |
-| `GET /b2b/passkey/list` | Bearer Token | 一覧取得 |
-| `DELETE /b2b/passkey/{credentialId}` | Bearer Token | 削除 |
-| `POST /token` | client_id + client_secret | トークン交換 |
+| `POST /v1/b2b/passkey/authenticate/options` | client_id | チャレンジ取得 |
+| `POST /v1/b2b/passkey/authenticate/verify` | client_id | 署名検証→認可コード |
+| `POST /v1/b2b/passkey/register/options` | client_id + client_secret | 登録オプション |
+| `POST /v1/b2b/passkey/register/verify` | client_id + client_secret | 登録完了 |
+| `GET /v1/b2b/passkey/list` | Bearer Token | 一覧取得 |
+| `DELETE /v1/b2b/passkey/{credentialId}` | Bearer Token | 削除 |
+| `POST /v1/token` | client_id + client_secret | トークン交換 |
 
 ## コーディング規約
 

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -41,7 +41,7 @@ class EcAuthApiClient
             $body['b2b_subject'] = $b2bSubject;
         }
 
-        return $this->post('/b2b/passkey/authenticate/options', $body);
+        return $this->post('/v1/b2b/passkey/authenticate/options', $body);
     }
 
     /**
@@ -62,7 +62,7 @@ class EcAuthApiClient
             $body['state'] = $state;
         }
 
-        return $this->post('/b2b/passkey/authenticate/verify', $body);
+        return $this->post('/v1/b2b/passkey/authenticate/verify', $body);
     }
 
     /**
@@ -85,7 +85,7 @@ class EcAuthApiClient
             $body['device_name'] = $deviceName;
         }
 
-        return $this->postWithSecret('/b2b/passkey/register/options', $body);
+        return $this->postWithSecret('/v1/b2b/passkey/register/options', $body);
     }
 
     /**
@@ -105,7 +105,7 @@ class EcAuthApiClient
             $body['device_name'] = $deviceName;
         }
 
-        return $this->postWithSecret('/b2b/passkey/register/verify', $body);
+        return $this->postWithSecret('/v1/b2b/passkey/register/verify', $body);
     }
 
     /**
@@ -115,7 +115,7 @@ class EcAuthApiClient
      */
     public function listPasskeys(string $accessToken): array
     {
-        return $this->request('GET', '/b2b/passkey/list', [], [
+        return $this->request('GET', '/v1/b2b/passkey/list', [], [
             'Authorization' => 'Bearer '.$accessToken,
         ]);
     }
@@ -127,7 +127,7 @@ class EcAuthApiClient
      */
     public function deletePasskey(string $accessToken, string $credentialId): array
     {
-        return $this->request('DELETE', '/b2b/passkey/'.urlencode($credentialId), [], [
+        return $this->request('DELETE', '/v1/b2b/passkey/'.urlencode($credentialId), [], [
             'Authorization' => 'Bearer '.$accessToken,
         ]);
     }
@@ -139,7 +139,7 @@ class EcAuthApiClient
      */
     public function exchangeToken(string $code, string $redirectUri): array
     {
-        return $this->postForm('/token', [
+        return $this->postForm('/v1/token', [
             'grant_type' => 'authorization_code',
             'code' => $code,
             'redirect_uri' => $redirectUri,


### PR DESCRIPTION
## Summary
- EcAuth 側の API バージョニング導入に伴い、EcAuthApiClient の全エンドポイントパスを `/v1/...` に更新
- B2Bパスキー関連エンドポイント（authenticate, register, list, delete）
- トークン交換エンドポイント（`/token`）

## Test plan
- [ ] PHPStan でエラーがないこと
- [ ] E2E テストがパスすること

Refs: EcAuth/EcAuth#348

🤖 Generated with [Claude Code](https://claude.com/claude-code)