### PR TITLE
feat(admin): Client ID によるテナント自動解決で設定画面を簡素化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,32 @@ ec-cube4-ecauth/
 
 - **Entity プロパティ名は snake_case** を使用する（EC-CUBE 本体の規約に準拠）。PSR-12 の camelCase 推奨よりも EC-CUBE 本体との一貫性を優先する
 - EC-CUBE 本体のコーディングスタイルに従う
+- **関数定義（パラメータ）の末尾カンマは禁止**。PHP 8.0+ の構文であり、PHP 7.4 で動作しなくなるため。配列リテラルと関数呼び出しの末尾カンマ（PHP 7.3+ で可）はそのまま使ってよい
+  - `Tests/.php-cs-fixer.dist.php` の `trailing_comma_in_multiline` から `parameters` を除外済み（`arrays` / `arguments` のみ対象）
+  - `Tests/rector.php` の `phpVersion` は `PHP_74` に固定（7.4 互換のリファクタのみ適用）
+
+## HTTP クライアント (PSR-18)
+
+プラグイン内の HTTP 通信は **PSR-18 (`Psr\Http\Client\ClientInterface`)** の抽象に依存する。`GuzzleHttp\Client` を直接 `new` したり `use` したりしない。
+
+- DI するインタフェース:
+  - `Psr\Http\Client\ClientInterface` — HTTP 送信
+  - `Psr\Http\Message\RequestFactoryInterface` — PSR-7 Request 生成
+  - `Psr\Http\Message\StreamFactoryInterface` — PSR-7 Body 生成
+- 実装バインドは `Resource/config/services.yaml` の以下 3 エントリで一元管理:
+  ```yaml
+  Psr\Http\Client\ClientInterface:
+      class: GuzzleHttp\Client
+      arguments:
+          - { timeout: 30, http_errors: false }
+  Psr\Http\Message\RequestFactoryInterface:
+      class: GuzzleHttp\Psr7\HttpFactory
+  Psr\Http\Message\StreamFactoryInterface:
+      class: GuzzleHttp\Psr7\HttpFactory
+  ```
+- EC-CUBE 4.2+ は本体が `guzzlehttp/guzzle:^7` を依存として持つため Guzzle を利用。実装を差し替える場合は本エントリの class のみ変更する
+- `composer.json` は `psr/http-client` / `psr/http-factory` / `psr/http-message` のみを require し、Guzzle は直接 require しない（本体経由で解決）
+- 例外捕捉は `Psr\Http\Client\ClientExceptionInterface` を使う（Guzzle 固有の例外型には依存しない）
 
 ## セキュリティ注意事項
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,27 @@ ec-cube4-ecauth/
 - `composer.json` は `psr/http-client` / `psr/http-factory` / `psr/http-message` のみを require し、Guzzle は直接 require しない（本体経由で解決）
 - 例外捕捉は `Psr\Http\Client\ClientExceptionInterface` を使う（Guzzle 固有の例外型には依存しない）
 
+## 環境変数の取り扱い
+
+**コード内で `getenv()` / `$_ENV` を直接参照しない**。Symfony の env プロセッサ (`%env(...)%`) を経由して DI で注入する。
+
+- 環境変数名は `services.yaml` の `bind:` または個別サービスの `arguments:` で `%env(...)%` 展開してパラメータとしてサービスに渡す
+- デフォルト値 (env 未設定時のフォールバック) は `parameters:` に定義し、`%env(default:<param名>:<ENV名>)%` で参照する
+  ```yaml
+  parameters:
+      ecauth_default_discovery_url: 'https://api.ec-auth.io'
+
+  services:
+      Plugin\EcAuthLogin43\:
+          # ...
+          bind:
+              $discoveryUrl: '%env(default:ecauth_default_discovery_url:ECAUTH_CLIENT_RESOLVE_URL)%'
+  ```
+- メリット:
+  - モックテストで env を書き換えずにコンストラクタ引数で値を注入できる
+  - `bin/console debug:container --env-vars` で env 使用箇所を一覧できる
+  - env 未設定時のフォールバック値がコードではなく config に集約される
+
 ## セキュリティ注意事項
 
 - client_secret はサーバーサイドのみ。JS に渡さない

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -32,7 +32,7 @@ class ConfigController extends AbstractController
     public function __construct(
         ConfigRepository $configRepository,
         ClientResolveService $clientResolveService,
-        TranslatorInterface $translator,
+        TranslatorInterface $translator
     ) {
         $this->configRepository = $configRepository;
         $this->clientResolveService = $clientResolveService;

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -32,7 +32,7 @@ class ConfigController extends AbstractController
     public function __construct(
         ConfigRepository $configRepository,
         ClientResolveService $clientResolveService,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
     ) {
         $this->configRepository = $configRepository;
         $this->clientResolveService = $clientResolveService;
@@ -59,7 +59,7 @@ class ConfigController extends AbstractController
                 $resolved = $this->clientResolveService->resolve((string) $Config->getClientId());
                 if (!$resolved['success']) {
                     $form->get('client_id')->addError(
-                        new FormError($this->translator->trans('ecauth_login43.admin.config.client_resolve.failed'))
+                        new FormError($this->translator->trans('ecauth_login43.admin.config.client_resolve.failed')),
                     );
 
                     return [

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -5,22 +5,38 @@ namespace Plugin\EcAuthLogin43\Controller\Admin;
 use Eccube\Controller\AbstractController;
 use Plugin\EcAuthLogin43\Form\Type\Admin\ConfigType;
 use Plugin\EcAuthLogin43\Repository\ConfigRepository;
+use Plugin\EcAuthLogin43\Service\ClientResolveService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ConfigController extends AbstractController
 {
-    private const BASE_DOMAIN = '.ec-auth.io';
-
     /**
      * @var ConfigRepository
      */
     protected $configRepository;
 
-    public function __construct(ConfigRepository $configRepository)
-    {
+    /**
+     * @var ClientResolveService
+     */
+    protected $clientResolveService;
+
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    public function __construct(
+        ConfigRepository $configRepository,
+        ClientResolveService $clientResolveService,
+        TranslatorInterface $translator
+    ) {
         $this->configRepository = $configRepository;
+        $this->clientResolveService = $clientResolveService;
+        $this->translator = $translator;
     }
 
     /**
@@ -32,21 +48,29 @@ class ConfigController extends AbstractController
         $Config = $this->configRepository->get();
         $hasClientSecret = $Config && $Config->getClientSecret() !== null && $Config->getClientSecret() !== '';
 
-        // DB のフル URL からサブドメイン部分を抽出してフォームにセット
-        $subdomain = $this->extractSubdomain($Config ? $Config->getEcauthBaseUrl() : null);
-        if ($subdomain !== null) {
-            $Config->setEcauthBaseUrl($subdomain);
-        }
-
         $form = $this->createForm(ConfigType::class, $Config);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $Config = $form->getData();
 
-            // サブドメインをフル URL に変換して保存
-            $inputSubdomain = $Config->getEcauthBaseUrl();
-            $Config->setEcauthBaseUrl('https://' . $inputSubdomain . self::BASE_DOMAIN);
+            $inputUrl = trim((string) $Config->getEcauthBaseUrl());
+            if ($inputUrl === '') {
+                $resolved = $this->clientResolveService->resolve((string) $Config->getClientId());
+                if (!$resolved['success']) {
+                    $form->get('client_id')->addError(
+                        new FormError($this->translator->trans('ecauth_login43.admin.config.client_resolve.failed'))
+                    );
+
+                    return [
+                        'form' => $form->createView(),
+                        'has_client_secret' => $hasClientSecret,
+                    ];
+                }
+                $Config->setEcauthBaseUrl($resolved['base_url']);
+            } else {
+                $Config->setEcauthBaseUrl(rtrim($inputUrl, '/'));
+            }
 
             $clientSecret = $form->get('client_secret')->getData();
             if ($clientSecret !== null && $clientSecret !== '') {
@@ -64,20 +88,5 @@ class ConfigController extends AbstractController
             'form' => $form->createView(),
             'has_client_secret' => $hasClientSecret,
         ];
-    }
-
-    private function extractSubdomain(?string $baseUrl): ?string
-    {
-        if ($baseUrl === null || $baseUrl === '') {
-            return null;
-        }
-
-        // https://{subdomain}.ec-auth.io からサブドメインを抽出
-        $pattern = '#^https?://(.+)' . preg_quote(self::BASE_DOMAIN, '#') . '/?$#';
-        if (preg_match($pattern, $baseUrl, $matches)) {
-            return $matches[1];
-        }
-
-        return null;
     }
 }

--- a/Controller/Admin/PasskeyController.php
+++ b/Controller/Admin/PasskeyController.php
@@ -30,7 +30,7 @@ class PasskeyController extends AbstractController
     public function __construct(
         EcAuthApiClient $apiClient,
         PasskeyAuthService $passkeyAuthService,
-        string $ecauth_auth_js_version,
+        string $ecauth_auth_js_version
     ) {
         $this->apiClient = $apiClient;
         $this->passkeyAuthService = $passkeyAuthService;

--- a/Controller/PasskeyAuthController.php
+++ b/Controller/PasskeyAuthController.php
@@ -24,7 +24,7 @@ class PasskeyAuthController extends AbstractController
 
     public function __construct(
         EcAuthApiClient $apiClient,
-        PasskeyAuthService $passkeyAuthService,
+        PasskeyAuthService $passkeyAuthService
     ) {
         $this->apiClient = $apiClient;
         $this->passkeyAuthService = $passkeyAuthService;

--- a/Form/Type/Admin/ConfigType.php
+++ b/Form/Type/Admin/ConfigType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Url;
 
 class ConfigType extends AbstractType
 {
@@ -16,8 +17,9 @@ class ConfigType extends AbstractType
     {
         $builder
             ->add('ecauth_base_url', TextType::class, [
+                'required' => false,
                 'constraints' => [
-                    new NotBlank(),
+                    new Url(['protocols' => ['https', 'http']]),
                 ],
             ])
             ->add('client_id', TextType::class, [

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -1,5 +1,8 @@
 parameters:
     ecauth_auth_js_version: 'latest'
+    # Client Resolve API の Discovery URL デフォルト値。
+    # 環境変数 ECAUTH_CLIENT_RESOLVE_URL が設定されていればそちらが優先される。
+    ecauth_default_discovery_url: 'https://api.ec-auth.io'
 
 services:
     Plugin\EcAuthLogin43\:
@@ -9,6 +12,7 @@ services:
         autoconfigure: true
         bind:
             $ecauth_auth_js_version: '%ecauth_auth_js_version%'
+            $discoveryUrl: '%env(default:ecauth_default_discovery_url:ECAUTH_CLIENT_RESOLVE_URL)%'
 
     # PSR-18 HTTP クライアント
     # EC-CUBE 4.2+ は本体が guzzlehttp/guzzle:^7 を依存として持つため Guzzle にエイリアス。

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -10,6 +10,20 @@ services:
         bind:
             $ecauth_auth_js_version: '%ecauth_auth_js_version%'
 
+    # PSR-18 HTTP クライアント
+    # EC-CUBE 4.2+ は本体が guzzlehttp/guzzle:^7 を依存として持つため Guzzle にエイリアス。
+    # 実装を差し替える場合は本エントリの class のみ変更する。
+    Psr\Http\Client\ClientInterface:
+        class: GuzzleHttp\Client
+        arguments:
+            - { timeout: 30, http_errors: false }
+
+    # PSR-17 Request / Stream ファクトリ (GuzzleHttp\Psr7\HttpFactory が両方を実装)
+    Psr\Http\Message\RequestFactoryInterface:
+        class: GuzzleHttp\Psr7\HttpFactory
+    Psr\Http\Message\StreamFactoryInterface:
+        class: GuzzleHttp\Psr7\HttpFactory
+
 eccube:
     rate_limiter:
         ecauth_passkey_authenticate:

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -2,12 +2,15 @@
 ecauth_login43.admin.config.title: EcAuth 設定
 ecauth_login43.admin.config.sub_title: プラグイン設定
 ecauth_login43.admin.config.header: EcAuth 接続設定
-ecauth_login43.admin.config.ecauth_base_url: Organization Code
-ecauth_login43.admin.config.ecauth_base_url.help: EcAuth のサブドメイン（Organization Code）を入力してください。
+ecauth_login43.admin.config.ecauth_base_url: EcAuth URL
+ecauth_login43.admin.config.ecauth_base_url.help: 通常は未入力で構いません。Client ID から自動解決されます。ステージング・開発環境では直接 URL を指定できます。
 ecauth_login43.admin.config.client_id: Client ID
 ecauth_login43.admin.config.client_secret: Client Secret
 ecauth_login43.admin.config.rp_id: RP ID
 ecauth_login43.admin.config.rp_id.help: 未設定の場合、サイトのホスト名が使用されます。
+ecauth_login43.admin.config.advanced_settings: 高度な設定
+ecauth_login43.admin.config.advanced_settings.help: 通常は変更不要です。ステージング・開発環境や RP ID のカスタマイズが必要な場合のみ使用してください。
+ecauth_login43.admin.config.client_resolve.failed: Client ID に対応するテナントが見つかりませんでした。Client ID を確認するか、高度な設定で EcAuth URL を直接指定してください。
 ecauth_login43.admin.config.required: 必須
 ecauth_login43.admin.config.save: 登録
 ecauth_login43.admin.config.back: 戻る

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -43,7 +43,7 @@
 
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
-                            <button class="btn btn-link p-0 text-decoration-none" type="button" data-toggle="collapse" data-target="#ecauth-advanced-settings" aria-expanded="false" aria-controls="ecauth-advanced-settings">
+                            <button class="btn btn-link p-0 text-decoration-none" type="button" data-bs-toggle="collapse" data-bs-target="#ecauth-advanced-settings" aria-expanded="false" aria-controls="ecauth-advanced-settings">
                                 <i class="fa fa-caret-right mr-1"></i>
                                 <span>{{ 'ecauth_login43.admin.config.advanced_settings'|trans }}</span>
                             </button>

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -43,10 +43,10 @@
 
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
-                            <a class="text-decoration-none" data-toggle="collapse" href="#ecauth-advanced-settings" role="button" aria-expanded="false" aria-controls="ecauth-advanced-settings">
+                            <button class="btn btn-link p-0 text-decoration-none" type="button" data-toggle="collapse" data-target="#ecauth-advanced-settings" aria-expanded="false" aria-controls="ecauth-advanced-settings">
                                 <i class="fa fa-caret-right mr-1"></i>
                                 <span>{{ 'ecauth_login43.admin.config.advanced_settings'|trans }}</span>
-                            </a>
+                            </button>
                         </div>
                         <div id="ecauth-advanced-settings" class="collapse">
                             <div class="card-body">

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -20,25 +20,6 @@
                         <div class="card-body">
                             <div class="row mb-2">
                                 <div class="col-3">
-                                    <span>{{ 'ecauth_login43.admin.config.ecauth_base_url'|trans }}</span>
-                                    <span class="badge badge-primary ml-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
-                                </div>
-                                <div class="col">
-                                    <div class="input-group">
-                                        <div class="input-group-prepend">
-                                            <span class="input-group-text">https://</span>
-                                        </div>
-                                        {{ form_widget(form.ecauth_base_url) }}
-                                        <div class="input-group-append">
-                                            <span class="input-group-text">.ec-auth.io</span>
-                                        </div>
-                                    </div>
-                                    {{ form_errors(form.ecauth_base_url) }}
-                                    <p class="form-text text-muted">{{ 'ecauth_login43.admin.config.ecauth_base_url.help'|trans }}</p>
-                                </div>
-                            </div>
-                            <div class="row mb-2">
-                                <div class="col-3">
                                     <span>{{ 'ecauth_login43.admin.config.client_id'|trans }}</span>
                                     <span class="badge badge-primary ml-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
                                 </div>
@@ -57,14 +38,38 @@
                                     {{ form_errors(form.client_secret) }}
                                 </div>
                             </div>
-                            <div class="row mb-2">
-                                <div class="col-3">
-                                    <span>{{ 'ecauth_login43.admin.config.rp_id'|trans }}</span>
+                        </div>
+                    </div>
+
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header">
+                            <a class="text-decoration-none" data-toggle="collapse" href="#ecauth-advanced-settings" role="button" aria-expanded="false" aria-controls="ecauth-advanced-settings">
+                                <i class="fa fa-caret-right mr-1"></i>
+                                <span>{{ 'ecauth_login43.admin.config.advanced_settings'|trans }}</span>
+                            </a>
+                        </div>
+                        <div id="ecauth-advanced-settings" class="collapse">
+                            <div class="card-body">
+                                <p class="form-text text-muted mb-3">{{ 'ecauth_login43.admin.config.advanced_settings.help'|trans }}</p>
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'ecauth_login43.admin.config.ecauth_base_url'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        {{ form_widget(form.ecauth_base_url, { attr: { placeholder: 'https://shop1.ec-auth.io' } }) }}
+                                        {{ form_errors(form.ecauth_base_url) }}
+                                        <p class="form-text text-muted">{{ 'ecauth_login43.admin.config.ecauth_base_url.help'|trans }}</p>
+                                    </div>
                                 </div>
-                                <div class="col">
-                                    {{ form_widget(form.rp_id) }}
-                                    {{ form_errors(form.rp_id) }}
-                                    <p class="form-text text-muted">{{ 'ecauth_login43.admin.config.rp_id.help'|trans }}</p>
+                                <div class="row mb-2">
+                                    <div class="col-3">
+                                        <span>{{ 'ecauth_login43.admin.config.rp_id'|trans }}</span>
+                                    </div>
+                                    <div class="col">
+                                        {{ form_widget(form.rp_id) }}
+                                        {{ form_errors(form.rp_id) }}
+                                        <p class="form-text text-muted">{{ 'ecauth_login43.admin.config.rp_id.help'|trans }}</p>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -21,7 +21,7 @@
                             <div class="row mb-2">
                                 <div class="col-3">
                                     <span>{{ 'ecauth_login43.admin.config.client_id'|trans }}</span>
-                                    <span class="badge badge-primary ml-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
+                                    <span class="badge badge-primary ms-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
                                 </div>
                                 <div class="col">
                                     {{ form_widget(form.client_id) }}
@@ -31,7 +31,7 @@
                             <div class="row mb-2">
                                 <div class="col-3">
                                     <span>{{ 'ecauth_login43.admin.config.client_secret'|trans }}</span>
-                                    <span class="badge badge-primary ml-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
+                                    <span class="badge badge-primary ms-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
                                 </div>
                                 <div class="col">
                                     {{ form_widget(form.client_secret, { attr: has_client_secret ? { placeholder: '••••••••••••••••' } : {} }) }}
@@ -44,7 +44,7 @@
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
                             <button class="btn btn-link p-0 text-decoration-none" type="button" data-bs-toggle="collapse" data-bs-target="#ecauth-advanced-settings" aria-expanded="false" aria-controls="ecauth-advanced-settings">
-                                <i class="fa fa-caret-right mr-1"></i>
+                                <i class="fa fa-caret-right me-1"></i>
                                 <span>{{ 'ecauth_login43.admin.config.advanced_settings'|trans }}</span>
                             </button>
                         </div>

--- a/Service/ClientResolveService.php
+++ b/Service/ClientResolveService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Service;
+
+use GuzzleHttp\Client;
+use Psr\Log\LoggerInterface;
+
+class ClientResolveService
+{
+    private const DEFAULT_DISCOVERY_URL = 'https://api.ec-auth.io';
+
+    private const CLIENT_RESOLVE_PATH = '/platform/v1/client-resolve';
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Client ID から Base URL を解決する。
+     *
+     * @return array{
+     *     success: bool,
+     *     status: int,
+     *     tenant_name?: string,
+     *     base_url?: string,
+     *     organization_name?: string,
+     *     error?: string,
+     * }
+     */
+    public function resolve(string $clientId): array
+    {
+        if ($clientId === '') {
+            return [
+                'success' => false,
+                'status' => 400,
+                'error' => 'client_id_empty',
+            ];
+        }
+
+        $url = $this->getDiscoveryUrl().self::CLIENT_RESOLVE_PATH;
+        $client = new Client();
+
+        try {
+            $response = $client->request('GET', $url, [
+                'query' => ['client_id' => $clientId],
+                'headers' => [
+                    'Accept' => 'application/json',
+                ],
+                'http_errors' => false,
+                'timeout' => 10,
+            ]);
+            $statusCode = $response->getStatusCode();
+            $content = json_decode($response->getBody()->getContents(), true) ?? [];
+
+            if ($statusCode === 200 && isset($content['tenant_name'], $content['base_url'])) {
+                return [
+                    'success' => true,
+                    'status' => $statusCode,
+                    'tenant_name' => $content['tenant_name'],
+                    'base_url' => $content['base_url'],
+                    'organization_name' => $content['organization_name'] ?? '',
+                ];
+            }
+
+            $this->logger->error('EcAuth client-resolve error', [
+                'status' => $statusCode,
+                'response' => $content,
+            ]);
+
+            return [
+                'success' => false,
+                'status' => $statusCode,
+                'error' => $content['error'] ?? 'unknown_error',
+            ];
+        } catch (\Exception $e) {
+            $this->logger->error('EcAuth client-resolve request failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [
+                'success' => false,
+                'status' => 0,
+                'error' => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Discovery エンドポイントの Base URL を取得する。
+     * 環境変数 ECAUTH_CLIENT_RESOLVE_URL で上書き可能（ステージング・開発環境用）。
+     */
+    private function getDiscoveryUrl(): string
+    {
+        $override = getenv('ECAUTH_CLIENT_RESOLVE_URL');
+        if ($override !== false && $override !== '') {
+            return rtrim($override, '/');
+        }
+
+        return self::DEFAULT_DISCOVERY_URL;
+    }
+}

--- a/Service/ClientResolveService.php
+++ b/Service/ClientResolveService.php
@@ -31,7 +31,7 @@ class ClientResolveService
     public function __construct(
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
-        LoggerInterface $logger,
+        LoggerInterface $logger
     ) {
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;

--- a/Service/ClientResolveService.php
+++ b/Service/ClientResolveService.php
@@ -76,7 +76,9 @@ class ClientResolveService
         try {
             $response = $this->httpClient->sendRequest($request);
             $statusCode = $response->getStatusCode();
-            $content = json_decode((string) $response->getBody(), true) ?? [];
+            // json_decode はスカラーも返しうる。?? はスカラーを拾わないため is_array で確実に配列化する。
+            $decoded = json_decode((string) $response->getBody(), true);
+            $content = is_array($decoded) ? $decoded : [];
 
             if ($statusCode === 200 && isset($content['tenant_name'], $content['base_url'])) {
                 return [

--- a/Service/ClientResolveService.php
+++ b/Service/ClientResolveService.php
@@ -2,7 +2,9 @@
 
 namespace Plugin\EcAuthLogin43\Service;
 
-use GuzzleHttp\Client;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Log\LoggerInterface;
 
 class ClientResolveService
@@ -12,12 +14,27 @@ class ClientResolveService
     private const CLIENT_RESOLVE_PATH = '/platform/v1/client-resolve';
 
     /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
 
-    public function __construct(LoggerInterface $logger)
-    {
+    public function __construct(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        LoggerInterface $logger,
+    ) {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
         $this->logger = $logger;
     }
 
@@ -43,20 +60,17 @@ class ClientResolveService
             ];
         }
 
-        $url = $this->getDiscoveryUrl().self::CLIENT_RESOLVE_PATH;
-        $client = new Client();
+        $url = $this->getDiscoveryUrl().self::CLIENT_RESOLVE_PATH
+            .'?'.http_build_query(['client_id' => $clientId]);
+
+        $request = $this->requestFactory
+            ->createRequest('GET', $url)
+            ->withHeader('Accept', 'application/json');
 
         try {
-            $response = $client->request('GET', $url, [
-                'query' => ['client_id' => $clientId],
-                'headers' => [
-                    'Accept' => 'application/json',
-                ],
-                'http_errors' => false,
-                'timeout' => 10,
-            ]);
+            $response = $this->httpClient->sendRequest($request);
             $statusCode = $response->getStatusCode();
-            $content = json_decode($response->getBody()->getContents(), true) ?? [];
+            $content = json_decode((string) $response->getBody(), true) ?? [];
 
             if ($statusCode === 200 && isset($content['tenant_name'], $content['base_url'])) {
                 return [
@@ -78,7 +92,7 @@ class ClientResolveService
                 'status' => $statusCode,
                 'error' => $content['error'] ?? 'unknown_error',
             ];
-        } catch (\Exception $e) {
+        } catch (ClientExceptionInterface $e) {
             $this->logger->error('EcAuth client-resolve request failed', [
                 'error' => $e->getMessage(),
             ]);

--- a/Service/ClientResolveService.php
+++ b/Service/ClientResolveService.php
@@ -9,8 +9,6 @@ use Psr\Log\LoggerInterface;
 
 class ClientResolveService
 {
-    private const DEFAULT_DISCOVERY_URL = 'https://api.ec-auth.io';
-
     private const CLIENT_RESOLVE_PATH = '/platform/v1/client-resolve';
 
     /**
@@ -28,14 +26,22 @@ class ClientResolveService
      */
     private $logger;
 
+    /**
+     * @var string Discovery エンドポイントの Base URL。
+     *             services.yaml で %env(default:ecauth_default_discovery_url:ECAUTH_CLIENT_RESOLVE_URL)% からバインドされる。
+     */
+    private $discoveryUrl;
+
     public function __construct(
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
-        LoggerInterface $logger
+        LoggerInterface $logger,
+        string $discoveryUrl
     ) {
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->logger = $logger;
+        $this->discoveryUrl = rtrim($discoveryUrl, '/');
     }
 
     /**
@@ -60,7 +66,7 @@ class ClientResolveService
             ];
         }
 
-        $url = $this->getDiscoveryUrl().self::CLIENT_RESOLVE_PATH
+        $url = $this->discoveryUrl.self::CLIENT_RESOLVE_PATH
             .'?'.http_build_query(['client_id' => $clientId]);
 
         $request = $this->requestFactory
@@ -103,19 +109,5 @@ class ClientResolveService
                 'error' => $e->getMessage(),
             ];
         }
-    }
-
-    /**
-     * Discovery エンドポイントの Base URL を取得する。
-     * 環境変数 ECAUTH_CLIENT_RESOLVE_URL で上書き可能（ステージング・開発環境用）。
-     */
-    private function getDiscoveryUrl(): string
-    {
-        $override = getenv('ECAUTH_CLIENT_RESOLVE_URL');
-        if ($override !== false && $override !== '') {
-            return rtrim($override, '/');
-        }
-
-        return self::DEFAULT_DISCOVERY_URL;
     }
 }

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -265,7 +265,9 @@ class EcAuthApiClient
         try {
             $response = $this->httpClient->sendRequest($request);
             $statusCode = $response->getStatusCode();
-            $content = json_decode((string) $response->getBody(), true) ?? [];
+            // json_decode はスカラーも返しうる。?? はスカラーを拾わないため is_array で確実に配列化する。
+            $decoded = json_decode((string) $response->getBody(), true);
+            $content = is_array($decoded) ? $decoded : [];
 
             if ($statusCode >= 400) {
                 $this->logger->error('EcAuth API error', [

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -42,7 +42,7 @@ class EcAuthApiClient
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
         StreamFactoryInterface $streamFactory,
-        LoggerInterface $logger,
+        LoggerInterface $logger
     ) {
         $this->configRepository = $configRepository;
         $this->httpClient = $httpClient;

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -2,8 +2,12 @@
 
 namespace Plugin\EcAuthLogin43\Service;
 
-use GuzzleHttp\Client;
 use Plugin\EcAuthLogin43\Repository\ConfigRepository;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
 
 class EcAuthApiClient
@@ -14,22 +18,41 @@ class EcAuthApiClient
     private $configRepository;
 
     /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    /**
+     * @var StreamFactoryInterface
+     */
+    private $streamFactory;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
 
     public function __construct(
         ConfigRepository $configRepository,
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        StreamFactoryInterface $streamFactory,
         LoggerInterface $logger,
     ) {
         $this->configRepository = $configRepository;
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->streamFactory = $streamFactory;
         $this->logger = $logger;
     }
 
     /**
      * パスキー認証オプションを取得する。
-     *
-     *
      */
     public function authenticateOptions(string $rpId, ?string $b2bSubject = null): array
     {
@@ -48,7 +71,6 @@ class EcAuthApiClient
      * パスキー認証を検証する。
      *
      * @param array $response WebAuthn assertion response
-     *
      */
     public function authenticateVerify(string $sessionId, string $redirectUri, ?string $state, array $response): array
     {
@@ -67,8 +89,6 @@ class EcAuthApiClient
 
     /**
      * パスキー登録オプションを取得する。
-     *
-     *
      */
     public function registerOptions(string $rpId, string $b2bSubject, string $externalId, ?string $displayName = null, ?string $deviceName = null): array
     {
@@ -92,7 +112,6 @@ class EcAuthApiClient
      * パスキー登録を完了する。
      *
      * @param array $response WebAuthn attestation response
-     *
      */
     public function registerVerify(string $sessionId, array $response, ?string $deviceName = null): array
     {
@@ -110,8 +129,6 @@ class EcAuthApiClient
 
     /**
      * 登録済みパスキー一覧を取得する。
-     *
-     *
      */
     public function listPasskeys(string $accessToken): array
     {
@@ -122,8 +139,6 @@ class EcAuthApiClient
 
     /**
      * パスキーを削除する。
-     *
-     *
      */
     public function deletePasskey(string $accessToken, string $credentialId): array
     {
@@ -134,8 +149,6 @@ class EcAuthApiClient
 
     /**
      * 認可コードをトークンに交換する。
-     *
-     *
      */
     public function exchangeToken(string $code, string $redirectUri): array
     {
@@ -202,48 +215,18 @@ class EcAuthApiClient
                 'data' => ['error' => 'EcAuth Base URL is not configured'],
             ];
         }
-        $url = $baseUrl.$path;
-        $client = new Client();
 
-        try {
-            $response = $client->request('POST', $url, [
-                'form_params' => $params,
-                'headers' => [
-                    'Accept' => 'application/json',
-                ],
-                'http_errors' => false,
-                'timeout' => 30,
-            ]);
-            $statusCode = $response->getStatusCode();
-            $content = json_decode($response->getBody()->getContents(), true) ?? [];
+        $request = $this->requestFactory
+            ->createRequest('POST', $baseUrl.$path)
+            ->withHeader('Accept', 'application/json')
+            ->withHeader('Content-Type', 'application/x-www-form-urlencoded')
+            ->withBody($this->streamFactory->createStream(http_build_query($params)));
 
-            if ($statusCode >= 400) {
-                $this->logger->error('EcAuth API error', [
-                    'status' => $statusCode,
-                    'path' => $path,
-                    'response' => $this->redactSensitiveFields($content),
-                ]);
-            }
-
-            return [
-                'status' => $statusCode,
-                'data' => $content,
-            ];
-        } catch (\Exception $e) {
-            $this->logger->error('EcAuth API request failed', [
-                'path' => $path,
-                'error' => $e->getMessage(),
-            ]);
-
-            return [
-                'status' => 500,
-                'data' => ['error' => $e->getMessage()],
-            ];
-        }
+        return $this->sendAndDecode($request, $path);
     }
 
     /**
-     * EcAuth API にリクエストを送信する。
+     * EcAuth API にリクエストを送信する (JSON ボディ)。
      */
     private function request(string $method, string $path, array $body = [], array $headers = []): array
     {
@@ -256,26 +239,33 @@ class EcAuthApiClient
                 'data' => ['error' => 'EcAuth Base URL is not configured'],
             ];
         }
-        $url = $baseUrl.$path;
-        $client = new Client();
 
-        $options = [
-            'headers' => array_merge([
-                'Content-Type' => 'application/json',
-                'Accept' => 'application/json',
-            ], $headers),
-            'http_errors' => false,
-            'timeout' => 30,
-        ];
+        $request = $this->requestFactory
+            ->createRequest($method, $baseUrl.$path)
+            ->withHeader('Accept', 'application/json');
 
-        if ($body !== []) {
-            $options['json'] = $body;
+        foreach ($headers as $name => $value) {
+            $request = $request->withHeader($name, $value);
         }
 
+        if ($body !== []) {
+            $request = $request
+                ->withHeader('Content-Type', 'application/json')
+                ->withBody($this->streamFactory->createStream((string) json_encode($body)));
+        }
+
+        return $this->sendAndDecode($request, $path);
+    }
+
+    /**
+     * PSR-7 Request を送信し、ステータスと JSON デコード済みボディを返す共通処理。
+     */
+    private function sendAndDecode(RequestInterface $request, string $path): array
+    {
         try {
-            $response = $client->request($method, $url, $options);
+            $response = $this->httpClient->sendRequest($request);
             $statusCode = $response->getStatusCode();
-            $content = json_decode($response->getBody()->getContents(), true) ?? [];
+            $content = json_decode((string) $response->getBody(), true) ?? [];
 
             if ($statusCode >= 400) {
                 $this->logger->error('EcAuth API error', [
@@ -289,7 +279,7 @@ class EcAuthApiClient
                 'status' => $statusCode,
                 'data' => $content,
             ];
-        } catch (\Exception $e) {
+        } catch (ClientExceptionInterface $e) {
             $this->logger->error('EcAuth API request failed', [
                 'path' => $path,
                 'error' => $e->getMessage(),

--- a/Service/PasskeyAuthService.php
+++ b/Service/PasskeyAuthService.php
@@ -57,7 +57,7 @@ class PasskeyAuthService
         EcAuthApiClient $apiClient,
         TokenStorageInterface $tokenStorage,
         UserPasswordHasherInterface $passwordHasher,
-        LoggerInterface $logger,
+        LoggerInterface $logger
     ) {
         $this->entityManager = $entityManager;
         $this->memberRepository = $memberRepository;

--- a/Tests/.php-cs-fixer.dist.php
+++ b/Tests/.php-cs-fixer.dist.php
@@ -24,7 +24,8 @@ return (new PhpCsFixer\Config())
         'no_unused_imports' => true,
         'ordered_imports' => ['sort_algorithm' => 'alpha'],
         'single_quote' => true,
-        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments', 'parameters']],
+        // parameters は PHP 8.0+ のため除外し PHP 7.4 での動作互換を維持
+        'trailing_comma_in_multiline' => ['elements' => ['arrays', 'arguments']],
         'blank_line_before_statement' => [
             'statements' => ['return'],
         ],

--- a/Tests/rector.php
+++ b/Tests/rector.php
@@ -21,7 +21,8 @@ return static function (RectorConfig $rectorConfig): void {
         __DIR__.'/../vendor',
     ]);
 
-    $rectorConfig->phpVersion(\Rector\ValueObject\PhpVersion::PHP_83);
+    // PHP 7.4 互換を維持したいので Rector のターゲットも PHP_74 に固定する
+    $rectorConfig->phpVersion(\Rector\ValueObject\PhpVersion::PHP_74);
 
     $rectorConfig->sets([
         SetList::CODE_QUALITY,

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -4,6 +4,9 @@ const ADMIN_URL = '/admin';
 const LOGIN_ID = process.env.ADMIN_LOGIN_ID || 'admin';
 const PASSWORD = process.env.ADMIN_PASSWORD || 'password';
 
+const ADVANCED_TOGGLE = 'button[data-toggle="collapse"][data-target="#ecauth-advanced-settings"]';
+const ADVANCED_PANEL = '#ecauth-advanced-settings';
+
 test.describe('プラグイン設定画面', () => {
   test.beforeEach(async ({ page }) => {
     // 管理画面ログイン
@@ -27,14 +30,13 @@ test.describe('プラグイン設定画面', () => {
     await expect(page.locator('input[name="config[client_secret]"]')).toBeVisible();
 
     // 高度な設定は折りたたまれている
-    const advanced = page.locator('#ecauth-advanced-settings');
-    await expect(advanced).not.toBeVisible();
+    await expect(page.locator(ADVANCED_PANEL)).not.toHaveClass(/show/);
     await expect(page.locator('input[name="config[ecauth_base_url]"]')).not.toBeVisible();
     await expect(page.locator('input[name="config[rp_id]"]')).not.toBeVisible();
 
     // トグルをクリックすると展開される
-    await page.click('a[data-toggle="collapse"][href="#ecauth-advanced-settings"]');
-    await expect(advanced).toBeVisible();
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
     await expect(page.locator('input[name="config[ecauth_base_url]"]')).toBeVisible();
   });
 
@@ -45,7 +47,8 @@ test.describe('プラグイン設定画面', () => {
     await page.fill('input[name="config[client_secret]"]', 'test-client-secret');
 
     // 高度な設定を展開して URL を入力（resolve をスキップ）
-    await page.click('a[data-toggle="collapse"][href="#ecauth-advanced-settings"]');
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
     await page.fill('input[name="config[ecauth_base_url]"]', 'https://auth.example.com');
 
     await page.click('button[type="submit"]');
@@ -56,7 +59,8 @@ test.describe('プラグイン設定画面', () => {
     // 値が永続化されていることを確認
     await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
     await expect(page.locator('input[name="config[client_id]"]')).toHaveValue('test-client-id');
-    await page.click('a[data-toggle="collapse"][href="#ecauth-advanced-settings"]');
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
     await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue('https://auth.example.com');
   });
 });

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -4,7 +4,7 @@ const ADMIN_URL = '/admin';
 const LOGIN_ID = process.env.ADMIN_LOGIN_ID || 'admin';
 const PASSWORD = process.env.ADMIN_PASSWORD || 'password';
 
-const ADVANCED_TOGGLE = 'button[data-toggle="collapse"][data-target="#ecauth-advanced-settings"]';
+const ADVANCED_TOGGLE = 'button[data-bs-toggle="collapse"][data-bs-target="#ecauth-advanced-settings"]';
 const ADVANCED_PANEL = '#ecauth-advanced-settings';
 
 test.describe('プラグイン設定画面', () => {

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -19,12 +19,34 @@ test.describe('プラグイン設定画面', () => {
     await expect(page.locator('text=EcAuth 接続設定')).toBeVisible();
   });
 
-  test('設定を保存できる', async ({ page }) => {
+  test('高度な設定がデフォルトで折りたたまれている', async ({ page }) => {
     await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
 
-    await page.fill('input[name="config[ecauth_base_url]"]', 'https://auth.example.com');
+    // Client ID / Client Secret はメインカードに表示
+    await expect(page.locator('input[name="config[client_id]"]')).toBeVisible();
+    await expect(page.locator('input[name="config[client_secret]"]')).toBeVisible();
+
+    // 高度な設定は折りたたまれている
+    const advanced = page.locator('#ecauth-advanced-settings');
+    await expect(advanced).not.toBeVisible();
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).not.toBeVisible();
+    await expect(page.locator('input[name="config[rp_id]"]')).not.toBeVisible();
+
+    // トグルをクリックすると展開される
+    await page.click('a[data-toggle="collapse"][href="#ecauth-advanced-settings"]');
+    await expect(advanced).toBeVisible();
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toBeVisible();
+  });
+
+  test('高度な設定で URL を直接指定して保存できる', async ({ page }) => {
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+
     await page.fill('input[name="config[client_id]"]', 'test-client-id');
     await page.fill('input[name="config[client_secret]"]', 'test-client-secret');
+
+    // 高度な設定を展開して URL を入力（resolve をスキップ）
+    await page.click('a[data-toggle="collapse"][href="#ecauth-advanced-settings"]');
+    await page.fill('input[name="config[ecauth_base_url]"]', 'https://auth.example.com');
 
     await page.click('button[type="submit"]');
 
@@ -33,7 +55,8 @@ test.describe('プラグイン設定画面', () => {
 
     // 値が永続化されていることを確認
     await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
-    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue('https://auth.example.com');
     await expect(page.locator('input[name="config[client_id]"]')).toHaveValue('test-client-id');
+    await page.click('a[data-toggle="collapse"][href="#ecauth-advanced-settings"]');
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue('https://auth.example.com');
   });
 });

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,10 @@
     "id": 999999
   },
   "require": {
-    "ec-cube/plugin-installer": "^2.0"
+    "ec-cube/plugin-installer": "^2.0",
+    "psr/http-client": "^1.0",
+    "psr/http-factory": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",


### PR DESCRIPTION
## Summary

- 設定画面を **Client ID / Client Secret の 2 項目のみ** で完結できるよう簡素化
- EcAuth URL と RP ID は「高度な設定」として折りたたみ（デフォルト非表示）
- EcAuth URL 未入力時は `GET /platform/v1/client-resolve?client_id=xxx` でテナントを自動解決
- Discovery URL はデフォルト `https://api.ec-auth.io`、環境変数 `ECAUTH_CLIENT_RESOLVE_URL` でオーバーライド可（staging/dev 用）

## 背景

現状、設定画面は 4 項目（EcAuth サブドメイン / Client ID / Client Secret / RP ID）すべて入力が必要で、特に「EcAuth サブドメイン」は一般ユーザーには自明ではありません。

EcAuth の Client ID はグローバルにユニーク (`IX_client_client_id`) なので、Client ID から Organization (= Base URL) を一意に特定できます。これを活用し、プラグインが EcAuth のテナント横断 API を呼び出して Base URL を自動解決することで、ユーザーが入力すべき項目を 2 つに絞ります。

## Changes

| ファイル | 変更内容 |
|----------|----------|
| `Service/ClientResolveService.php`（新規） | Client ID → Base URL 解決の HTTP クライアント |
| `Form/Type/Admin/ConfigType.php` | `ecauth_base_url` の NotBlank 削除、Url validation を optional 付与 |
| `Controller/Admin/ConfigController.php` | サブドメイン変換ロジック削除、URL 未入力時に resolve 呼び出し、失敗時 FormError |
| `Resource/template/admin/config.twig` | Bootstrap 4 collapse で「高度な設定」をトグル |
| `Resource/locale/messages.ja.yaml` | ラベル・ヘルプ・エラーメッセージ更新 |
| `Tests/specs/plugin_config.spec.ts` | 折りたたみ UI 挙動と高度設定経由の保存シナリオを追加 |

## 互換性

- **DB スキーマ変更なし**（`ecauth_base_url` は既に nullable）
- 既存環境で `ecauth_base_url` が保存済みの場合は従来通り動作（後方互換）

## 関連

- EcAuth/EcAuthDocs#58
- EcAuth/EcAuth#342 – `/platform/` 基盤（実装済み）
- EcAuth/ecauth-infrastructure#44 – `api.ec-auth.io` DNS・カスタムドメイン追加（本番公開用、先行適用が必要）

## Test plan

- [ ] `docker compose up -d --build` でローカル環境起動
- [ ] `/admin/ecauth_login43/config` を開き、デフォルトで Client ID / Client Secret のみが表示され、「高度な設定」が折りたたまれていること
- [ ] 高度な設定を展開し、EcAuth URL に Docker 内 EcAuth URL を直接入力 → 保存 → Passkey 管理画面の動作確認（resolve 経路をスキップするパス）
- [ ] `ECAUTH_CLIENT_RESOLVE_URL` を Docker 内 EcAuth に向けて設定し、Advanced URL 空で Client ID のみで保存 → DB の `ecauth_base_url` が埋まること
- [ ] 存在しない Client ID で保存 → `ecauth_login43.admin.config.client_resolve.failed` メッセージが表示され、DB 未更新であること
- [ ] 既存環境で `ecauth_base_url` が保存済みの Config を GET → フル URL がそのままフォームに表示されること（後方互換確認）
- [ ] `pnpm exec playwright test Tests/specs/plugin_config.spec.ts`
- [ ] CI の PHPStan / php-cs-fixer / rector が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Client IDからEcAuth URLを自動解決する機能を追加しました
  * 「詳細設定」折りたたみセクションでEcAuth URLとRP IDを設定可能にしました（デフォルトは折りたたみ）

* **改善**
  * EcAuth URLは空許容かつHTTP/HTTPS形式を検証、末尾スラッシュを除去して保存します（プレースホルダ追加）
  * 管理画面のラベル・ヘルプ文言を更新し、詳細設定の説明を追加しました

* **バグ修正**
  * Client ID解決失敗時に該当フィールドへ翻訳済みのフォームエラーを表示します

* **テスト**
  * 詳細設定の表示/保存動作を確認するE2Eテストを追加・更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->