### PR TITLE
feat: B2B パスキー認証を PKCE (RFC 7636 / S256) 対応させる

### DIFF
--- a/Controller/PasskeyAuthController.php
+++ b/Controller/PasskeyAuthController.php
@@ -93,6 +93,12 @@ class PasskeyAuthController extends AbstractController
         $state = bin2hex(random_bytes(32));
         $session->set('ecauth_state', $state);
 
+        // PKCE (RFC 7636) の code_verifier を生成してセッションに保存し、
+        // code_challenge のみを EcAuth に送る。verifier はブラウザを一度も経由せず、
+        // コールバック時に PHP 側でトークン交換に使う。
+        $codeVerifier = $this->passkeyAuthService->generateCodeVerifier();
+        $session->set('ecauth_code_verifier', $codeVerifier);
+
         $redirectUri = $this->generateUrl('ecauth_callback', [], UrlGeneratorInterface::ABSOLUTE_URL);
 
         $result = $this->apiClient->authenticateVerify(
@@ -100,10 +106,14 @@ class PasskeyAuthController extends AbstractController
             $redirectUri,
             $state,
             $data['response'],
+            $this->passkeyAuthService->generateCodeChallenge($codeVerifier),
         );
 
         if ($result['status'] !== 200) {
+            // 失敗した verifier を残すと、次回認証時に新しい challenge と食い違って
+            // トークン交換が invalid_grant になる。state と揃えて必ず破棄する。
             $session->remove('ecauth_state');
+            $session->remove('ecauth_code_verifier');
 
             return $this->json(['error' => 'Authentication failed'], $result['status']);
         }

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -71,8 +71,10 @@ class EcAuthApiClient
      * パスキー認証を検証する。
      *
      * @param array $response WebAuthn assertion response
+     * @param string|null $codeChallenge PKCE (RFC 7636) の code_challenge。指定すると発行される
+     *                                   認可コードに束縛され、トークン交換時に code_verifier が必須になる
      */
-    public function authenticateVerify(string $sessionId, string $redirectUri, ?string $state, array $response): array
+    public function authenticateVerify(string $sessionId, string $redirectUri, ?string $state, array $response, ?string $codeChallenge = null): array
     {
         $body = [
             'session_id' => $sessionId,
@@ -82,6 +84,10 @@ class EcAuthApiClient
         ];
         if ($state !== null) {
             $body['state'] = $state;
+        }
+        if ($codeChallenge !== null) {
+            $body['code_challenge'] = $codeChallenge;
+            $body['code_challenge_method'] = 'S256';
         }
 
         return $this->post('/v1/b2b/passkey/authenticate/verify', $body);
@@ -149,16 +155,24 @@ class EcAuthApiClient
 
     /**
      * 認可コードをトークンに交換する。
+     *
+     * @param string|null $codeVerifier PKCE (RFC 7636) の code_verifier。authenticate/verify で
+     *                                  code_challenge を送った場合は必須
      */
-    public function exchangeToken(string $code, string $redirectUri): array
+    public function exchangeToken(string $code, string $redirectUri, ?string $codeVerifier = null): array
     {
-        return $this->postForm('/v1/token', [
+        $params = [
             'grant_type' => 'authorization_code',
             'code' => $code,
             'redirect_uri' => $redirectUri,
             'client_id' => $this->getClientId(),
             'client_secret' => $this->getClientSecret(),
-        ]);
+        ];
+        if ($codeVerifier !== null) {
+            $params['code_verifier'] = $codeVerifier;
+        }
+
+        return $this->postForm('/v1/token', $params);
     }
 
     private function getClientId(): string

--- a/Service/PasskeyAuthService.php
+++ b/Service/PasskeyAuthService.php
@@ -110,10 +110,25 @@ class PasskeyAuthService
         $savedState = $session->get('ecauth_state');
         $session->remove('ecauth_state');
 
+        // PKCE の code_verifier を取り出して使い捨てる。
+        // state 検証より前に取り出すのは、state 不一致で離脱する経路でも
+        // セッションに verifier を残さないため。
+        $savedCodeVerifier = $session->get('ecauth_code_verifier');
+        $session->remove('ecauth_code_verifier');
+        $codeVerifier = is_string($savedCodeVerifier) && $savedCodeVerifier !== '' ? $savedCodeVerifier : null;
+
         if ($savedState === null || !hash_equals($savedState, $state)) {
             $this->logger->warning('EcAuth callback state mismatch');
 
             return null;
+        }
+
+        // state は通ったのに verifier だけ無い場合は、認可コードに束縛された
+        // code_challenge と突き合わせられずトークン交換が invalid_grant になる。
+        // 原因を追えるようここで警告を残す（state 検証後に置くことで、
+        // 単なる期限切れコールバックでの重複警告を避ける）。
+        if ($codeVerifier === null) {
+            $this->logger->warning('EcAuth callback missing code_verifier in session');
         }
 
         // トークン交換
@@ -121,7 +136,7 @@ class PasskeyAuthService
         // 失敗時でも provider 実装によっては部分的な値が混入する可能性があるため、
         // ここでは body 全体ではなく OAuth 標準のエラーフィールド + キー一覧のみ出す。
         // 完全な redact 済みレスポンスは EcAuthApiClient::sendAndDecode 側で別途記録される。
-        $tokenResult = $this->apiClient->exchangeToken($code, $redirectUri);
+        $tokenResult = $this->apiClient->exchangeToken($code, $redirectUri, $codeVerifier);
         if ($tokenResult['status'] !== 200) {
             $response = $tokenResult['data'] ?? null;
             $this->logger->error('EcAuth token exchange failed', [
@@ -259,6 +274,30 @@ class PasskeyAuthService
         ]);
     }
 
+    /**
+     * PKCE (RFC 7636) の code_verifier を生成する。
+     *
+     * RFC 7636 Section 4.1 は 43〜128 文字の unreserved を要求する。
+     * 32 バイトの乱数を base64url した 43 文字はこの下限ちょうどで、
+     * かつ 256bit のエントロピーを持つ。
+     */
+    public function generateCodeVerifier(): string
+    {
+        return $this->base64UrlEncode(random_bytes(32));
+    }
+
+    /**
+     * code_verifier から code_challenge を導出する。
+     *
+     * RFC 7636 Section 4.2: BASE64URL-ENCODE(SHA256(ASCII(code_verifier)))
+     * hash() の第3引数 (raw binary) を落とすと hex 文字列をエンコードした別物になり、
+     * EcAuth 側は形式を検証しないためトークン交換まで失敗が露見しない。
+     */
+    public function generateCodeChallenge(string $codeVerifier): string
+    {
+        return $this->base64UrlEncode(hash('sha256', $codeVerifier, true));
+    }
+
     private function base64UrlDecode(string $input): ?string
     {
         $remainder = strlen($input) % 4;
@@ -268,6 +307,11 @@ class PasskeyAuthService
         $decoded = base64_decode(strtr($input, '-_', '+/'), true);
 
         return $decoded === false ? null : $decoded;
+    }
+
+    private function base64UrlEncode(string $raw): string
+    {
+        return rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
     }
 
     /**


### PR DESCRIPTION
Closes #35

## Summary

B2B パスキー認証の認可コードフローを PKCE (RFC 7636 / S256) 対応させました。

`authenticate/verify` で `code_challenge` を送って認可コードに束縛し、コールバックでのトークン交換に `code_verifier` を添えます。EcAuth 側は EcAuth#457 / #464 で対応済みです。

**code_verifier は一度もブラウザを経由しません。** プラグインは `authenticate/verify` を自前のサーバーサイドエンドポイントでプロキシし、トークン交換も PHP で行うため、verifier の生成・保持・提示がすべてサーバー内で完結します。CDN 配信の `ecauth-auth.umd.js` は無変更です。

```
[PHP] verifier 生成 → challenge を authenticate/verify へ送信 → 認可コードに束縛
  ↓ verifier はセッションに保存（ブラウザには渡さない）
[Browser] redirect_url へ遷移（code のみ）
  ↓
[PHP] callback で verifier を取り出し → /v1/token に code_verifier を添えて交換
```

## Changes

- **`Service/PasskeyAuthService.php`**: `generateCodeVerifier()` / `generateCodeChallenge()` と base64url encode ヘルパを追加（decode は既存）。`handleCallback()` で verifier を消費してトークン交換に渡す
- **`Controller/PasskeyAuthController.php`**: verifier を生成してセッションに保存し、challenge を送信。認証失敗時は `ecauth_state` と揃えて verifier も破棄する
- **`Service/EcAuthApiClient.php`**: `authenticateVerify()` に `code_challenge`、`exchangeToken()` に `code_verifier` を任意パラメータとして追加

メソッド名は ec-cube2-ecauth の B2C 経路に既にある `generateCodeVerifier` / `generateCodeChallenge` に揃えました（EcAuth/ec-cube2-ecauth#6 で同じ命名が出てきます）。

## 互換性

いずれも任意パラメータのため、**EcAuth 本体との同時デプロイは不要**です。3 通りすべて壊れません。

| 組合せ | 挙動 |
|---|---|
| 新プラグイン × 新 EcAuth | challenge 束縛 → トークン交換時に verifier 検証 → 200 |
| 新プラグイン × 旧 EcAuth | `code_challenge` は未知の JSON メンバーとして捨てられる（`System.Text.Json` の既定は skip）。challenge が束縛されないので `code_verifier` は無視され 200 |
| 旧プラグイン × 新 EcAuth | challenge 未送信 → confidential client なので従来どおり 200 |

リリース順序の制約は **EcAuth#472（PKCE 必須化）より前にリリースすること** のみです。

## Test plan

- [x] Rector dry-run → `[OK] Rector is done!`
- [x] PHP CS Fixer dry-run → `Found 0 of 14 files that can be fixed`
- [x] challenge 導出を **RFC 7636 Appendix B の公式テストベクタ**で検証（`dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk` → `E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM` 一致）。verifier は 43 文字・unreserved のみ
- [x] **CI（Playwright E2E / CI / Claude Code Review）すべて success**
- [x] **ローカル実機でのパスキーログイン成功を確認**。EC-CUBE 4.3 + staging EcAuth に対して `Tests/specs/passkey_auth.spec.ts` 全 7 件 pass、プラグインログに `EcAuth passkey authentication successful` を確認（＝`code_verifier` 付きトークン交換が 200）
- [x] 連続実行で verifier が毎回再生成されること（複数回のログイン成功で確認）