### PR TITLE
feat(admin): 設定画面に EcAuth 申込・マイページ導線を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,23 @@ composer rector
 composer cs-check
 ```
 
+**重要**: 静的解析のために `composer install` を実行すると、リポジトリ直下に `vendor/` が生成される。
+`docker-compose.override.yml` はリポジトリ直下を `/plugin` にマウントし、`docker-entrypoint.sh` の
+`eccube:composer:require ec-cube/ecauthlogin43 --from=/plugin` がその `vendor/` ごとプラグインを取り込むため、
+EC-CUBE 本体のオートローダーと衝突して起動に失敗する。
+
+```
+PHP Fatal error: Cannot declare class Composer\Autoload\ClassLoader, because the name is already in use
+                 in /plugin/vendor/composer/ClassLoader.php
+```
+
+**Docker で動かす前に `rm -rf vendor` すること**（`vendor/` は `.gitignore` 済みで、生成物以外は失われない）。
+CI では静的解析ジョブと E2E ジョブが別コンテナのため、この衝突は起きない。
+
+同じ理由（リポジトリ直下がコンテナにマウントされている）で、`docker compose up` すると
+プラグインインストーラが **`composer.json` を minify した 1 行 JSON に書き戻す**。追跡ファイルなので
+`git status` に差分として現れる。コミットに混入させないよう `git checkout -- composer.json` で戻すこと。
+
 ### E2E テスト
 
 ```bash

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -29,14 +29,34 @@ class ConfigController extends AbstractController
      */
     protected $translator;
 
+    /**
+     * 申込フォーム (ec-auth.io) の URL。services.yaml の
+     * ecauth_default_signup_url / 環境変数 ECAUTH_SIGNUP_URL で決まる。
+     *
+     * @var string
+     */
+    protected $signupUrl;
+
+    /**
+     * マイページ (ec-auth.io) の URL。services.yaml の
+     * ecauth_default_mypage_url / 環境変数 ECAUTH_MYPAGE_URL で決まる。
+     *
+     * @var string
+     */
+    protected $mypageUrl;
+
     public function __construct(
         ConfigRepository $configRepository,
         ClientResolveService $clientResolveService,
-        TranslatorInterface $translator
+        TranslatorInterface $translator,
+        string $signupUrl,
+        string $mypageUrl
     ) {
         $this->configRepository = $configRepository;
         $this->clientResolveService = $clientResolveService;
         $this->translator = $translator;
+        $this->signupUrl = $signupUrl;
+        $this->mypageUrl = $mypageUrl;
     }
 
     /**
@@ -71,6 +91,8 @@ class ConfigController extends AbstractController
                     return [
                         'form' => $form->createView(),
                         'has_client_secret' => $hasClientSecret,
+                        'signup_url' => $this->signupUrl,
+                        'mypage_url' => $this->mypageUrl,
                     ];
                 }
                 $Config->setEcauthBaseUrl($resolved['base_url']);
@@ -93,6 +115,8 @@ class ConfigController extends AbstractController
         return [
             'form' => $form->createView(),
             'has_client_secret' => $hasClientSecret,
+            'signup_url' => $this->signupUrl,
+            'mypage_url' => $this->mypageUrl,
         ];
     }
 }

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -3,6 +3,11 @@ parameters:
     # Client Resolve API の Discovery URL デフォルト値。
     # 環境変数 ECAUTH_CLIENT_RESOLVE_URL が設定されていればそちらが優先される。
     ecauth_default_discovery_url: 'https://api.ec-auth.io'
+    # 設定画面に表示する申込 / マイページ導線の URL デフォルト値。
+    # Hugo 生成の実 URL に合わせて末尾スラッシュ付き (無いと 301 が挟まる)。
+    # 環境変数 ECAUTH_SIGNUP_URL / ECAUTH_MYPAGE_URL が設定されていればそちらが優先される。
+    ecauth_default_signup_url: 'https://ec-auth.io/signup/'
+    ecauth_default_mypage_url: 'https://ec-auth.io/mypage/'
 
 services:
     Plugin\EcAuthLogin43\:
@@ -13,6 +18,8 @@ services:
         bind:
             $ecauth_auth_js_version: '%ecauth_auth_js_version%'
             $discoveryUrl: '%env(default:ecauth_default_discovery_url:ECAUTH_CLIENT_RESOLVE_URL)%'
+            $signupUrl: '%env(default:ecauth_default_signup_url:ECAUTH_SIGNUP_URL)%'
+            $mypageUrl: '%env(default:ecauth_default_mypage_url:ECAUTH_MYPAGE_URL)%'
             $eccubeTimezone: '%timezone%'
 
     # PSR-18 HTTP クライアント

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -1,6 +1,16 @@
 # 設定画面
 ecauth_login43.admin.config.title: EcAuth 設定
 ecauth_login43.admin.config.sub_title: プラグイン設定
+ecauth_login43.admin.config.signup.header: Client ID / Client Secret の取得方法
+ecauth_login43.admin.config.signup.intro: 本プラグインのご利用には、EcAuth が発行する Client ID と Client Secret が必要です。まだお持ちでない場合は、以下の手順で取得してください。管理者 5 ユーザーまで無料でご利用いただけます。
+ecauth_login43.admin.config.signup.first_time.header: はじめて EcAuth をご利用の場合
+ecauth_login43.admin.config.signup.first_time.step1: 下の「EcAuth に申し込む」ボタンから申込フォームを開き、メールアドレスとサイトの情報を入力します。
+ecauth_login43.admin.config.signup.first_time.step2: 入力したメールアドレス宛に確認メールが届きます。メール内のリンクを開くと、EcAuth のアカウントが作成されます。
+ecauth_login43.admin.config.signup.first_time.step3: EcAuth のマイページに Client ID と Client Secret が表示されます。これを下の「EcAuth 接続設定」に入力し、「登録」ボタンを押してください。
+ecauth_login43.admin.config.signup.link: EcAuth に申し込む
+ecauth_login43.admin.config.signup.registered.header: すでにお申し込み済みの場合
+ecauth_login43.admin.config.signup.registered.description: 申込は不要です。EcAuth のマイページを開くと、ご契約中のショップの Client ID と Client Secret を確認できます。Client Secret が分からなくなった場合は、マイページから再発行できます。
+ecauth_login43.admin.config.signup.mypage.link: EcAuth マイページを開く
 ecauth_login43.admin.config.header: EcAuth 接続設定
 ecauth_login43.admin.config.ecauth_base_url: EcAuth URL
 ecauth_login43.admin.config.ecauth_base_url.help: 通常は未入力で構いません。Client ID から自動解決されます。ステージング・開発環境では直接 URL を指定できます。

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -7,6 +7,16 @@
 
 {% form_theme form '@admin/Form/bootstrap_4_horizontal_layout.html.twig' %}
 
+{% block stylesheet %}
+    <style>
+        /* 管理画面の CSS が li { list-style-type: none } を当てているため、
+           申込手順のリストだけ番号を戻す（他の一覧に影響させないよう id でスコープする） */
+        #ecauth-signup-steps li {
+            list-style-type: decimal;
+        }
+    </style>
+{% endblock %}
+
 {% block main %}
     <form role="form" method="post">
 
@@ -15,6 +25,31 @@
         <div class="c-contentsArea__cols">
             <div class="c-contentsArea__primaryCol">
                 <div class="c-primaryCol">
+                    <div class="card rounded border-0 mb-4">
+                        <div class="card-header"><span>{{ 'ecauth_login43.admin.config.signup.header'|trans }}</span></div>
+                        <div class="card-body">
+                            <p class="mb-4">{{ 'ecauth_login43.admin.config.signup.intro'|trans }}</p>
+
+                            <p class="fw-bold mb-2">{{ 'ecauth_login43.admin.config.signup.first_time.header'|trans }}</p>
+                            <ol id="ecauth-signup-steps" class="mb-3 ps-4">
+                                <li class="mb-1">{{ 'ecauth_login43.admin.config.signup.first_time.step1'|trans }}</li>
+                                <li class="mb-1">{{ 'ecauth_login43.admin.config.signup.first_time.step2'|trans }}</li>
+                                <li>{{ 'ecauth_login43.admin.config.signup.first_time.step3'|trans }}</li>
+                            </ol>
+                            <a class="btn btn-ec-regular" id="ecauth-signup-link" href="{{ signup_url }}" target="_blank" rel="noopener noreferrer">
+                                <i class="fa fa-external-link me-1"></i>{{ 'ecauth_login43.admin.config.signup.link'|trans }}
+                            </a>
+
+                            <hr class="my-4">
+
+                            <p class="fw-bold mb-2">{{ 'ecauth_login43.admin.config.signup.registered.header'|trans }}</p>
+                            <p class="mb-3">{{ 'ecauth_login43.admin.config.signup.registered.description'|trans }}</p>
+                            <a class="btn btn-ec-regular" id="ecauth-mypage-link" href="{{ mypage_url }}" target="_blank" rel="noopener noreferrer">
+                                <i class="fa fa-external-link me-1"></i>{{ 'ecauth_login43.admin.config.signup.mypage.link'|trans }}
+                            </a>
+                        </div>
+                    </div>
+
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header"><span>{{ 'ecauth_login43.admin.config.header'|trans }}</span></div>
                         <div class="card-body">

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -7,6 +7,11 @@ const PASSWORD = process.env.ADMIN_PASSWORD || 'password';
 const ADVANCED_TOGGLE = 'button[data-bs-toggle="collapse"][data-bs-target="#ecauth-advanced-settings"]';
 const ADVANCED_PANEL = '#ecauth-advanced-settings';
 
+// 導線の URL は services.yaml の parameters が既定値で、環境変数で上書きできる。
+// テスト側も同じ解決順にしておく（CI では環境変数未設定なので既定値が使われる）。
+const SIGNUP_URL = process.env.ECAUTH_SIGNUP_URL || 'https://ec-auth.io/signup/';
+const MYPAGE_URL = process.env.ECAUTH_MYPAGE_URL || 'https://ec-auth.io/mypage/';
+
 test.describe('プラグイン設定画面', () => {
   test.beforeEach(async ({ page }) => {
     // 管理画面ログイン
@@ -19,7 +24,34 @@ test.describe('プラグイン設定画面', () => {
 
   test('設定画面にアクセスできる', async ({ page }) => {
     await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
-    await expect(page.locator('text=EcAuth 接続設定')).toBeVisible();
+    // 部分一致だと導線カードの説明文（「下の『EcAuth 接続設定』に入力してください」）にも
+    // マッチして strict mode 違反になるため、カード見出しに完全一致させる
+    await expect(page.getByText('EcAuth 接続設定', { exact: true })).toBeVisible();
+  });
+
+  test('申込・マイページへの導線が表示される', async ({ page }) => {
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+
+    // 導線カードは接続設定カードより前（未設定の管理者が最初に目にする位置）に置く
+    await expect(page.locator('.c-primaryCol .card-header').first()).toContainText(
+      'Client ID / Client Secret の取得方法',
+    );
+    // はじめて利用する管理者向けに、申込〜設定までの手順を明示する
+    await expect(page.locator('text=はじめて EcAuth をご利用の場合')).toBeVisible();
+    await expect(page.locator('text=すでにお申し込み済みの場合')).toBeVisible();
+
+    const signup = page.locator('#ecauth-signup-link');
+    await expect(signup).toBeVisible();
+    await expect(signup).toHaveAttribute('href', SIGNUP_URL);
+    // 管理画面を離脱させないよう別タブで開く。target=_blank には rel の付与が必須
+    await expect(signup).toHaveAttribute('target', '_blank');
+    await expect(signup).toHaveAttribute('rel', /noopener/);
+
+    const mypage = page.locator('#ecauth-mypage-link');
+    await expect(mypage).toBeVisible();
+    await expect(mypage).toHaveAttribute('href', MYPAGE_URL);
+    await expect(mypage).toHaveAttribute('target', '_blank');
+    await expect(mypage).toHaveAttribute('rel', /noopener/);
   });
 
   test('高度な設定がデフォルトで折りたたまれている', async ({ page }) => {


### PR DESCRIPTION
## Summary

EC-CUBE 管理画面のプラグイン設定画面に、**Client ID / Client Secret の取得方法**を案内するカードを追加します。

プラグインをインストールした事業者が「Client ID / Client Secret をどこで入手すればいいのか」分からず行き止まる状態を解消するのが目的です（EcAuthDocs#39 Phase E-5）。

案内は 2 経路に分けて明示しています。

- **はじめて EcAuth をご利用の場合** — 申込 → 確認メール → マイページで発行 → 設定欄に入力、という手順を番号付きで提示し、「EcAuth に申し込む」ボタンを置く
- **すでにお申し込み済みの場合** — 申込は不要である旨と、マイページで確認・再発行できる旨を案内し、「EcAuth マイページを開く」ボタンを置く

## Changes

- `Resource/template/admin/config.twig` — 導線カードを接続設定カードより**前**に追加（未設定の管理者が最初に目にする位置）
  - 管理画面の CSS が `li { list-style-type: none }` を当てて手順の番号が消えるため、`block stylesheet` で id スコープを切って番号を戻す
  - 管理画面から離脱させないよう `target="_blank"` + `rel="noopener noreferrer"`
- `Resource/locale/messages.ja.yaml` — 案内文言を追加
- `Resource/config/services.yaml` / `Controller/Admin/ConfigController.php` — 導線 URL を parameters 既定値 + 環境変数 `ECAUTH_SIGNUP_URL` / `ECAUTH_MYPAGE_URL` で上書き可能にする（既存の `ecauth_default_discovery_url` と同じ解決順）
- `Tests/specs/plugin_config.spec.ts` — 導線の href / target / rel・配置順・2 経路の見出しを検証するテストを追加
  - 既存の `text=EcAuth 接続設定` は導線カードの説明文にも部分一致して strict mode 違反になるため、完全一致セレクタに変更
- `CLAUDE.md` — Docker 利用時の落とし穴を追記（後述）

## CLAUDE.md に追記した落とし穴

本 PR の作業中に踏んだもので、いずれもリポジトリ直下がコンテナに `/plugin` としてマウントされることに起因します。

1. 静的解析のために `composer install` すると生成される `vendor/` が `eccube:composer:require --from=/plugin` 経由で取り込まれ、EC-CUBE 本体のオートローダーと衝突して起動不能になる（`Cannot declare class Composer\Autoload\ClassLoader`）。Docker 起動前に `rm -rf vendor` が必要。
2. `docker compose up` するとプラグインインストーラが `composer.json` を minify した 1 行 JSON に書き戻す。追跡ファイルなのでコミットに混入しないよう戻す必要がある。

CI では静的解析ジョブと E2E ジョブが別コンテナのため、いずれも CI では発生しません。

## Test plan

- [x] `vendor/bin/php-cs-fixer fix --dry-run --diff --config Tests/.php-cs-fixer.dist.php` → `Found 0 of 14 files that can be fixed`
- [x] `vendor/bin/rector process --dry-run --config Tests/rector.php` → `[OK] Rector is done!`
- [x] `docker compose up -d --wait` で起動し、`BASE_URL=https://localhost:8081 pnpm exec playwright test Tests/specs/plugin_config.spec.ts` → **4 passed**
- [x] 設定画面のスクリーンショットで、手順の番号・2 経路の見出し・両ボタンの表示を目視確認
- [x] CI（Playwright E2E 全スペック）

Refs: EcAuth/EcAuthDocs#39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理画面のEcAuth設定に、申し込み手順を案内するカードを追加しました。
  * EcAuthの新規申し込みページとマイページへのリンクを追加しました。
  * リンク先を環境変数で設定できるようになりました。

* **ドキュメント**
  * 開発時に発生する環境構築上の注意点と回避手順を追記しました。

* **テスト**
  * 申し込み・マイページリンクの表示、遷移先、外部リンク属性を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->