### PR TITLE
fix: プラグイン ID をオーナーズストアのリリース版 ID に変更

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## プロジェクト概要
 
-EC-CUBE 4.3系管理画面向け EcAuth B2Bパスキー認証プラグイン（EcAuthLogin43）。
+EC-CUBE 4.2/4.3系管理画面向け EcAuth B2Bパスキー認証プラグイン（EcAuthLogin43）。
 EcAuth Identity Provider と連携し、管理画面にパスキー（WebAuthn/FIDO2）認証を追加する。
 
 ## 注意事項

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ EC-CUBE 4.2/4.3系管理画面向けの EcAuth B2Bパスキー認証プラグイ
 ## 要件
 
 - EC-CUBE 4.2/4.3系
-- PHP 8.3以上
+- PHP 7.4以上
 - HTTPS環境（WebAuthn必須）
 
 ## インストール

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# EcAuthLogin43 - EC-CUBE 4.3系 EcAuth 認証プラグイン
+# EcAuthLogin43 - EC-CUBE 4.2/4.3系 EcAuth 認証プラグイン
 
-EC-CUBE 4.3系管理画面向けの EcAuth B2Bパスキー認証プラグインです。
+EC-CUBE 4.2/4.3系管理画面向けの EcAuth B2Bパスキー認証プラグインです。
 
 ## 機能
 
@@ -10,7 +10,7 @@ EC-CUBE 4.3系管理画面向けの EcAuth B2Bパスキー認証プラグイン�
 
 ## 要件
 
-- EC-CUBE 4.3系
+- EC-CUBE 4.2/4.3系
 - PHP 8.3以上
 - HTTPS環境（WebAuthn必須）
 

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
   "name": "ec-cube/ecauthlogin43",
-  "version": "1.0.0",
-  "description": "EC-CUBE 4.3系向け EcAuth 認証プラグイン",
+  "version": "1.0.1",
+  "description": "EC-CUBE 4.2/4.3系向け EcAuth 認証プラグイン",
   "type": "eccube-plugin",
   "license": "LGPL-2.1-or-later",
   "extra": {
     "code": "EcAuthLogin43",
-    "id": 999999
+    "id": 3557
   },
   "require": {
     "ec-cube/plugin-installer": "^2.0",


### PR DESCRIPTION
## 概要

Fixes #38

`composer.json` の `extra.id` が開発用のダミー値 `999999` のままだったため、オーナーズストア公開版の product_id に差し替えます。あわせて対応バージョン・システム要件の記述を実態に合わせて修正します。

## 変更内容

### プラグイン ID

- `extra.id`: `999999` → `3557`
  - オーナーズストア商品「【パスキー対応】EcAuth プラグイン(4.2/4.3系)」（スキルニル株式会社）の product_id
  - issue 本文には `3357` と記載がありましたが、`3357` は別会社の「Google reCAPTCHA v3プラグイン(4.2系)」だったため、issue に併記された URL の `product_id=3557` を採用しています

### 対応 EC-CUBE バージョン表記（4.3系 → 4.2/4.3系）

オーナーズストアの商品名に合わせて統一。

- `composer.json` の `description`
- `README.md`（タイトル・概要・要件）
- `CLAUDE.md`（プロジェクト概要）

### システム要件（PHP 8.3以上 → PHP 7.4以上）

`README.md` の「PHP 8.3以上」は開発用 Docker 環境（`ghcr.io/ec-cube/ec-cube-php:8.3-apache-4.3`）の値を誤って要件として記載していたものです。実際のコードベースは PHP 7.4 互換を維持する方針です。

- `Tests/rector.php` は `PHP_74` にターゲット固定
- `Tests/.php-cs-fixer.dist.php` は `trailing_comma_in_multiline` から `parameters` を除外（PHP 8.0+ 構文の混入防止）
- `CLAUDE.md` にも「関数定義の末尾カンマは PHP 7.4 で動作しなくなるため禁止」と明記
- ソース全体を確認し、PHP 8.0+ 固有の構文・関数（`match`、`?->`、attributes、`readonly`、constructor promotion、union 型、`str_contains` 等）の使用は無し
- PHP 7.4.33 環境（417tea.cafe）で動作確認済み

### バージョン

- `version`: `1.0.0` → `1.0.1`（本 PR マージ後に v1.0.1 をリリース）

## CI について

E2E Tests の `passkey_auth.spec.ts:324 パスキーボタンクリックでログインが完了し管理画面に遷移する` が失敗していますが、これは base の main（8ac72a9）でも同様に失敗している既存の不安定テストで、本 PR の変更（メタデータとドキュメントのみ）とは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)