### PR TITLE
feat: 検証キー経由での package-api インストールに対応する

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -1,5 +1,11 @@
 # 1Password テンプレートファイル
-# 使用方法: op inject -i .env.tpl -o .env
+#
+# 使用方法（平文 .env を作らず、サブプロセスの環境変数としてのみ注入する）:
+#   op run --env-file=.env.tpl -- docker compose up -d --build
+#
+# 既定ではプラグインは /plugin（このリポジトリのワーキングツリー）からインストールされる。
+# オーナーズストアに申請中のパッケージを package-api 経由で検証する場合は
+# .env.verify.tpl を併用する。
 
 # EcAuth クライアント設定
 # CI (.github/workflows/playwright.yml) の注入名と揃えるため CLIENT_ID /

--- a/.env.verify.tpl
+++ b/.env.verify.tpl
@@ -1,0 +1,17 @@
+# 1Password テンプレートファイル（検証キー経路の追加分）
+#
+# オーナーズストアにリリース申請すると検証キー（X-ECCUBE-KEY）が発行される。
+# そのキーを使うと `bin/console eccube:composer:require` が実際の package-api と通信して
+# 「申請中のパッケージ」を取得できるため、公開前のパッケージを本番と同じ配布経路で
+# E2E 検証できる。
+#
+# 使用方法（.env.tpl と併用する）:
+#   op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
+#
+# バージョンを固定したい場合は非秘密なのでインラインで渡す:
+#   ECAUTH_PLUGIN_VERSION=1.0.1 op run --env-file=.env.tpl --env-file=.env.verify.tpl -- \
+#     docker compose up -d --build
+#
+# このファイルを読み込まなければ従来どおり /plugin のローカルソースからインストールされる。
+
+ECCUBE_AUTHENTICATION_KEY=op://EcAuth/eccube4-ecauth-plugin/eccube_authentication_key

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -5,6 +5,19 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      install_source:
+        description: 'プラグインのインストール元'
+        type: choice
+        options:
+          - local
+          - package-api
+        default: local
+      plugin_version:
+        description: 'package-api から入れるプラグインのバージョン（空なら最新）'
+        type: string
+        required: false
 
 jobs:
   e2e:
@@ -28,7 +41,7 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Load secrets from 1Password
-        uses: 1password/load-secrets-action@v4
+        uses: 1password/load-secrets-action@eb2efd0703da22a93c467f2d1ffbb6826c11e19c # v4.1.1
         with:
           export-env: true
         env:
@@ -37,8 +50,27 @@ jobs:
           STAGING_CLIENT_SECRET: op://EcAuth/ecauth-staging-app/client_secret
           STAGING_WEB_APP_SUFFIX: op://EcAuth/ecauth-staging-app/web_app_suffix
 
+      # オーナーズストアの検証キー（X-ECCUBE-KEY）。
+      # 設定されている場合のみ docker-entrypoint.sh が package-api から
+      # 「申請中のパッケージ」をインストールする。既定（push / pull_request）では
+      # このステップが動かないため、/plugin のローカルソースが使われる。
+      # fork からの PR には secrets が無いので、この分岐は必須。
+      - name: Load EC-CUBE verification key from 1Password
+        if: ${{ inputs.install_source == 'package-api' }}
+        uses: 1password/load-secrets-action@eb2efd0703da22a93c467f2d1ffbb6826c11e19c # v4.1.1
+        with:
+          export-env: true
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          ECCUBE_AUTHENTICATION_KEY: op://EcAuth/eccube4-ecauth-plugin/eccube_authentication_key
+
       - name: Start Docker environment
+        # ECCUBE_AUTHENTICATION_KEY は直前のステップが export-env で job の env に載せる
+        # （そのステップが動かなければ未設定のまま）。docker compose はそれを継承するので
+        # ここで再指定はしない。未設定＝ローカルソースからのインストール。
         run: docker compose up -d --build --wait
+        env:
+          ECAUTH_PLUGIN_VERSION: ${{ inputs.plugin_version }}
 
       - name: Wait for EC-CUBE to be ready
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,11 @@ ECAUTH_PLUGIN_VERSION=1.0.1 \
 composer require の前にこの値を DB へ書き込む。管理画面「オーナーズストア > 認証キー設定」で
 人が入力するのと同じ場所であり、EC-CUBE コアへのパッチではない。
 
-**キーの扱い**: 値はコマンド引数に載せず、標準入力で渡した PHP スクリプトが `getenv()` で
+**キーの扱い**: 値はコマンド引数に載せず、標準入力で渡した PHP スクリプトが `$_SERVER` から
 読む。`ps` や docker のコマンドラインに現れないようにするため。ログにも出力しない。
+（環境変数の参照に `getenv()` を使わないのは、スレッドセーフでなく Symfony でも非推奨のため。
+`$_ENV` は `variables_order` に `E` が無いと空になるが、`$_SERVER` は `EGPCS` / `GPCS` の
+どちらでも CLI SAPI が populate する。）
 
 CI では `workflow_dispatch` の `install_source` を `package-api` にしたときだけ
 1Password から読み込む（fork の PR には secrets が無いため、既定はローカルソース）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,43 @@ docker compose logs ec-cube
 docker compose down
 ```
 
+### プラグインのインストール元（ローカルソース / package-api）
+
+`docker-entrypoint.sh` は `ECCUBE_AUTHENTICATION_KEY` の有無でインストール元を切り替える。
+
+| `ECCUBE_AUTHENTICATION_KEY` | インストール元 | コマンド | 用途 |
+|---|---|---|---|
+| 未設定（既定） | `/plugin`（ワーキングツリー） | `eccube:composer:require ec-cube/ecauthlogin43 --from=/plugin` | 日常の開発・PR CI |
+| 設定済 | オーナーズストアの package-api | `eccube:composer:require ec-cube/ecauthlogin43 [version]` | 申請中パッケージの検証 |
+
+`eccube:composer:require` は `--from` を付けると path リポジトリを追加し、**そのパッケージを
+package-api リポジトリから exclude する**（`ComposerApiService::init()`）。したがって両立せず、
+どちらか一方になる。
+
+```bash
+# 既定（ローカルソース）
+op run --env-file=.env.tpl -- docker compose up -d --build
+
+# 検証キーで package-api から「申請中のパッケージ」を入れる
+op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
+
+# バージョンを固定する場合（非秘密なのでインラインで渡す）
+ECAUTH_PLUGIN_VERSION=1.0.1 \
+  op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
+```
+
+検証キー（`X-ECCUBE-KEY`）はオーナーズストアにリリース申請すると発行される。
+`ComposerApiService` は package-api へのリクエストに
+`X-ECCUBE-KEY: {dtb_base_info.authentication_key}` を付けるため、entrypoint は
+composer require の前にこの値を DB へ書き込む。管理画面「オーナーズストア > 認証キー設定」で
+人が入力するのと同じ場所であり、EC-CUBE コアへのパッチではない。
+
+**キーの扱い**: 値はコマンド引数に載せず、標準入力で渡した PHP スクリプトが `getenv()` で
+読む。`ps` や docker のコマンドラインに現れないようにするため。ログにも出力しない。
+
+CI では `workflow_dispatch` の `install_source` を `package-api` にしたときだけ
+1Password から読み込む（fork の PR には secrets が無いため、既定はローカルソース）。
+
 ### 静的解析
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,14 @@ services:
       APP_ENV: dev
       DATABASE_URL: "postgresql://eccube:password@postgres:5432/eccube_db"
       DATABASE_SERVER_VERSION: 15
+      # オーナーズストアのリリース申請で発行される検証キー（X-ECCUBE-KEY）。
+      # 設定すると docker-entrypoint.sh が package-api から「申請中のパッケージ」を
+      # インストールする。未設定なら従来どおり /plugin のローカルソースから入れる。
+      # 値は 1Password から渡す:
+      #   op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
+      ECCUBE_AUTHENTICATION_KEY: ${ECCUBE_AUTHENTICATION_KEY:-}
+      # package-api から入れるプラグインのバージョン（空なら最新）。非秘密なのでそのまま渡す。
+      ECAUTH_PLUGIN_VERSION: ${ECAUTH_PLUGIN_VERSION:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -33,18 +33,88 @@ bin/console doctrine:query:sql 'select * from dtb_base_info' > /dev/null 2>&1 ||
 
 echo "PassEnv APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS" > /etc/apache2/conf-enabled/eccube_env.conf
 
-# プラグインがまだインストールされていなければインストール
+# 検証キー（オーナーズストアのリリース申請で発行される X-ECCUBE-KEY）を
+# dtb_base_info.authentication_key に設定する。
+#
+# ComposerApiService は package-api リポジトリに `X-ECCUBE-KEY: {authentication_key}` を
+# 付けてリクエストするため、composer require の前に DB へ入れておく必要がある。
+# 管理画面「オーナーズストア > 認証キー設定」で人が入力するのと同じ場所であり、
+# EC-CUBE コアへのパッチではない。
+#
+# キーをコマンド引数に載せると `ps` や docker のコマンドラインに現れてしまうため、
+# スクリプトは標準入力から渡し、キー自体は PHP 側で getenv() する。
+# （プラグイン本体のコードでは env 直参照を禁止しているが、ここは DI コンテナの無い
+#   開発／CI 用エントリポイントであり、env 経由にすること自体が漏洩対策になっている）
+set_authentication_key() {
+    php <<'PHP'
+<?php
+// DATABASE_URL 例: postgresql://eccube:password@postgres:5432/eccube_db
+$url = parse_url((string) getenv('DATABASE_URL'));
+$key = (string) getenv('ECCUBE_AUTHENTICATION_KEY');
+
+if (!is_array($url) || !isset($url['host'], $url['path']) || $key === '') {
+    fwrite(STDERR, "authentication_key を設定できません（DATABASE_URL または ECCUBE_AUTHENTICATION_KEY が不正です）\n");
+    exit(1);
+}
+
+$driver = str_starts_with((string) ($url['scheme'] ?? 'postgresql'), 'mysql') ? 'mysql' : 'pgsql';
+$dsn = sprintf(
+    '%s:host=%s;port=%d;dbname=%s',
+    $driver,
+    $url['host'],
+    $url['port'] ?? ($driver === 'mysql' ? 3306 : 5432),
+    ltrim($url['path'], '/')
+);
+
+$pdo = new PDO(
+    $dsn,
+    rawurldecode((string) ($url['user'] ?? '')),
+    rawurldecode((string) ($url['pass'] ?? '')),
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+// dtb_base_info は単一行運用。値はプレースホルダで渡し SQL 文字列に埋め込まない。
+$pdo->prepare('UPDATE dtb_base_info SET authentication_key = ?')->execute([$key]);
+
+fwrite(STDOUT, "authentication_key を設定しました（値は出力しません）\n");
+PHP
+}
+
+# プラグインがまだインストールされていなければインストールする。
+#
+# インストール元は ECCUBE_AUTHENTICATION_KEY の有無で切り替える。
+#   未設定: /plugin（このリポジトリのワーキングツリー）から入れる。PR CI の既定動作。
+#   設定済: package-api から入れる。オーナーズストアにリリース申請すると検証キーが発行され、
+#           そのキーで「申請中のパッケージ」を取得できる。公開前のパッケージを実際の配布
+#           経路どおりに検証したいときに使う。
+#
+# eccube:composer:require は --from を付けると path リポジトリを追加し、そのパッケージを
+# package-api リポジトリから exclude する（ComposerApiService::init）。両立しないため
+# 明示的に分岐させる。
 plugin_list=$(bin/console eccube:plugin:list 2>/dev/null || true)
-if ! echo "$plugin_list" | grep -q EcAuthLogin43; then
-    echo "Installing EcAuthLogin43 plugin..."
-    bin/console eccube:composer:require ec-cube/ecauthlogin43 --from=/plugin
+if echo "$plugin_list" | grep -q EcAuthLogin43; then
+    echo "EcAuthLogin43 plugin already installed."
+else
+    if [ -n "${ECCUBE_AUTHENTICATION_KEY:-}" ]; then
+        echo "Installing EcAuthLogin43 from package-api (version: ${ECAUTH_PLUGIN_VERSION:-latest})..."
+        set_authentication_key
+        if [ -n "${ECAUTH_PLUGIN_VERSION:-}" ]; then
+            bin/console eccube:composer:require ec-cube/ecauthlogin43 "${ECAUTH_PLUGIN_VERSION}"
+        else
+            bin/console eccube:composer:require ec-cube/ecauthlogin43
+        fi
+    else
+        echo "Installing EcAuthLogin43 from /plugin (local source)..."
+        bin/console eccube:composer:require ec-cube/ecauthlogin43 --from=/plugin
+    fi
     bin/console eccube:plugin:enable --code=EcAuthLogin43
     bin/console cache:clear --no-warmup
     bin/console cache:warmup --no-optional-warmers
     echo "EcAuthLogin43 plugin installed and enabled."
-else
-    echo "EcAuthLogin43 plugin already installed."
 fi
+
+# どのソース・どのバージョンで入ったかを起動ログに残す（CI の失敗解析用）。
+bin/console eccube:plugin:list || true
 
 # Apache 起動
 exec "$@"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,15 +42,19 @@ echo "PassEnv APP_ENV APP_DEBUG TRUSTED_PROXIES TRUSTED_HOSTS" > /etc/apache2/co
 # EC-CUBE コアへのパッチではない。
 #
 # キーをコマンド引数に載せると `ps` や docker のコマンドラインに現れてしまうため、
-# スクリプトは標準入力から渡し、キー自体は PHP 側で getenv() する。
+# スクリプトは標準入力から渡し、キー自体は PHP 側で環境変数から読む。
 # （プラグイン本体のコードでは env 直参照を禁止しているが、ここは DI コンテナの無い
 #   開発／CI 用エントリポイントであり、env 経由にすること自体が漏洩対策になっている）
+#
+# 環境変数の参照は getenv() ではなく $_SERVER を使う。getenv() はスレッドセーフでなく
+# Symfony でも非推奨。$_ENV は variables_order に E が無いと空になるが、$_SERVER は
+# EGPCS / GPCS のどちらでも CLI SAPI が populate する。
 set_authentication_key() {
     php <<'PHP'
 <?php
 // DATABASE_URL 例: postgresql://eccube:password@postgres:5432/eccube_db
-$url = parse_url((string) getenv('DATABASE_URL'));
-$key = (string) getenv('ECCUBE_AUTHENTICATION_KEY');
+$url = parse_url((string) ($_SERVER['DATABASE_URL'] ?? ''));
+$key = (string) ($_SERVER['ECCUBE_AUTHENTICATION_KEY'] ?? '');
 
 if (!is_array($url) || !isset($url['host'], $url['path']) || $key === '') {
     fwrite(STDERR, "authentication_key を設定できません（DATABASE_URL または ECCUBE_AUTHENTICATION_KEY が不正です）\n");


### PR DESCRIPTION
## 背景

E2E 拡充の一環。オーナーズストアにリリース申請すると検証キー（`X-ECCUBE-KEY`）が発行され、`bin/console eccube:composer:require` が実際の package-api と通信して**申請中のパッケージ**を取得できる。公開前のパッケージを本番と同じ配布経路で E2E 検証できるよう、インストール元を切り替えられるようにする。

## 変更内容

`docker-entrypoint.sh` が `ECCUBE_AUTHENTICATION_KEY` の有無で分岐する。

| `ECCUBE_AUTHENTICATION_KEY` | インストール元 | コマンド | 用途 |
|---|---|---|---|
| 未設定（既定） | `/plugin`（ワーキングツリー） | `eccube:composer:require ec-cube/ecauthlogin43 --from=/plugin` | 日常の開発・PR CI |
| 設定済 | package-api | `eccube:composer:require ec-cube/ecauthlogin43 [version]` | 申請中パッケージの検証 |

`eccube:composer:require` は `--from` を付けると path リポジトリを追加し、**そのパッケージを package-api リポジトリから exclude する**（[`ComposerApiService::init()`](https://github.com/EC-CUBE/ec-cube/blob/4.3/src/Eccube/Service/Composer/ComposerApiService.php)）。両立しないため明示的な分岐が必要。

```bash
# 既定（従来どおり）
op run --env-file=.env.tpl -- docker compose up -d --build

# 検証キーで package-api から入れる
op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build

# バージョン固定（非秘密なのでインライン）
ECAUTH_PLUGIN_VERSION=1.0.1 \
  op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
```

## 検証キーの扱い

`ComposerApiService` は package-api へのリクエストに `X-ECCUBE-KEY: {dtb_base_info.authentication_key}` を付けるため、composer require の前にこの値を DB へ書き込む必要がある。これは管理画面「オーナーズストア > 認証キー設定」で人が入力するのと**同じ場所**であり、EC-CUBE コアへのパッチではない（CLAUDE.md の「コア側にパッチをあてない」に抵触しない）。

漏洩対策:

- 値を**コマンド引数に載せない**。`ps` や docker のコマンドラインに現れるため。標準入力から渡した PHP スクリプトが `getenv()` で読む
- SQL 文字列に埋め込まず**プレースホルダ**で渡す
- ログに出力しない（`set -x` も使わない）
- 供給元は 1Password のみ。`workflow_dispatch` の input にはしない（input は secret 扱いされず、run の event payload から読めてしまうため）

> なお CLAUDE.md の「コード内で `getenv()` を直接参照しない」はプラグイン本体（Symfony DI がある側）の規約です。ここは DI コンテナの無い開発／CI 用エントリポイントで、env 経由にすること自体が漏洩対策になっています。

## CI

`workflow_dispatch` に入力を追加。既定は従来どおりローカルソース。

| 入力 | 既定 | 内容 |
|---|---|---|
| `install_source` | `local` | `local` / `package-api` |
| `plugin_version` | 空 | package-api から入れる版（空なら最新） |

検証キーの 1Password 読み込みは `install_source == 'package-api'` のときだけ実行する。**fork からの PR には secrets が無い**ため、この分岐は必須。

`1password/load-secrets-action` は SHA ピン止めした（`eb2efd07…` = v4.1.1。`@v4` が現在指しているのと同じコミットなので挙動は変わらない）。

## 使う前に必要な準備

package-api 経路を使うときのみ必要（既定の動作には不要）:

`op://EcAuth/eccube4-ecauth-plugin` に **`eccube_authentication_key` フィールドを追加**してください。現時点では未作成であることを確認済みです。

## 検証

- [x] `bash -n docker-entrypoint.sh`
- [x] 埋め込み PHP の `php -l`
- [x] `playwright.yml` / `docker-compose.yml` の YAML パース
- [ ] 既定経路（ローカルソース）の E2E がこの PR の CI で通ること
- [ ] `workflow_dispatch` で `install_source=package-api` を選んだ実行（1Password フィールド追加後）

> package-api 経路は、ストア上のパッケージ名が `composer.json` の `name`（`ec-cube/ecauthlogin43`）と一致していることを前提にしています。初回実行時に確認をお願いします。

## 関連

- EcAuth#481 / EcAuth#482 / EcAuth#487
- ecauth-infrastructure#131

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プラグインをローカルソースまたは package-api から選択して導入できるようになりました。
  * package-api 利用時に、検証キーやプラグインバージョンを指定できるようになりました。
  * 起動時のプラグイン有効化、キャッシュ更新、導入状況の確認に対応しました。

* **改善**
  * Docker 環境で検証キーやバージョン設定を簡単に利用できるようになりました。
  * CI を手動実行し、導入元とプラグインバージョンを選択できるようになりました。

* **ドキュメント**
  * 1Password を利用した環境変数の設定手順と、プラグイン導入方法の説明を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->