### PR TITLE
fix: 存在しない eccube:plugin:list への依存をやめる

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -95,8 +95,11 @@ PHP
 # eccube:composer:require は --from を付けると path リポジトリを追加し、そのパッケージを
 # package-api リポジトリから exclude する（ComposerApiService::init）。両立しないため
 # 明示的に分岐させる。
-plugin_list=$(bin/console eccube:plugin:list 2>/dev/null || true)
-if echo "$plugin_list" | grep -q EcAuthLogin43; then
+# 導入済み判定には composer を使う。EC-CUBE 4.3 に eccube:plugin:list は存在せず
+# （bin/console が "Command not found" を返す）、それで判定すると常に未導入扱いになる。
+# コンテナを restart したときに再インストールへ走り、eccube:plugin:enable が
+# 「既に有効」で落ちて set -e により Apache が起動しない。
+if composer show ec-cube/ecauthlogin43 >/dev/null 2>&1; then
     echo "EcAuthLogin43 plugin already installed."
 else
     if [ -n "${ECCUBE_AUTHENTICATION_KEY:-}" ]; then
@@ -117,8 +120,11 @@ else
     echo "EcAuthLogin43 plugin installed and enabled."
 fi
 
-# どのソース・どのバージョンで入ったかを起動ログに残す（CI の失敗解析用）。
-bin/console eccube:plugin:list || true
+# どのバージョンで入ったかを起動ログに残す。
+# 検証キー経由（package-api）で回すときは「実際に配布された版が入ったか」がまさに
+# 確認したいことなので、成功時にも必ず残す。
+echo "--- installed plugin version ---"
+composer show ec-cube/ecauthlogin43 || true
 
 # Apache 起動
 exec "$@"


### PR DESCRIPTION
## 問題

`docker-entrypoint.sh` が使っている `bin/console eccube:plugin:list` は
**EC-CUBE 4.3 に存在しないコマンド**です。実際のコンテナログ:

```
EcAuthLogin43 plugin installed and enabled.

  Command "eccube:plugin:list" is not defined.

  Did you mean one of these?
      eccube:plugin:disable
      eccube:plugin:enable
      eccube:plugin:generate
      eccube:plugin:install
      eccube:plugin:schema-update
      eccube:plugin:uninstall
      eccube:plugin:update
```

これで 2 箇所が空振りしています。

### 1. 導入済み判定が常に「未導入」になる

```sh
plugin_list=$(bin/console eccube:plugin:list 2>/dev/null || true)
if echo "$plugin_list" | grep -q EcAuthLogin43; then
```

`plugin_list` は常に空なので `else` に落ちます。E2E は毎回 `down -v` するため実害は
出ていませんでしたが、**コンテナを restart すると**再インストールへ走り、
`eccube:plugin:enable` が「既に有効」で失敗 → `set -eo pipefail` により
`exec "$@"` に到達せず **Apache が起動しません**。

### 2. バージョン記録が何も出ていない

```sh
# どのソース・どのバージョンで入ったかを起動ログに残す（CI の失敗解析用）。
bin/console eccube:plugin:list || true
```

コメントの意図どおりに動いていません。v1.0.1 承認後の検証実行
（[EcAuth runs/30605353250](https://github.com/EcAuth/EcAuth/actions/runs/30605353250)）で
「package-api 経由で入った」ことまでは確認できても、**入った版が追えない**原因のひとつです。

## 変更

どちらも `composer` に寄せます。コンテナ内で動作確認済み:

```
$ composer show ec-cube/ecauthlogin43
name     : ec-cube/ecauthlogin43
descrip. : EC-CUBE 4.2/4.3系向け EcAuth 認証プラグイン
versions : * 1.0.1
type     : eccube-plugin
```

- 判定: `composer show ec-cube/ecauthlogin43 >/dev/null 2>&1`
- 記録: `composer show ec-cube/ecauthlogin43`（`--- installed plugin version ---` 見出し付き）

`bash -n` 済み。

## 関連

EcAuth 側でも、成功した run でコンテナログを捨てていた点を直します: EcAuth/EcAuth#492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 起動時のプラグイン導入判定を改善し、より確実にインストール状態を確認できるようになりました。
  - 起動時に表示されるバージョン情報が、Composerのパッケージ情報に基づく表示へ変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->