### PR TITLE
fix: 管理者パスキーログインが customer firewall のセッションを汚染する問題を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,3 +216,11 @@ ec-cube4-ecauth/
 - state パラメータは hash_equals() で検証、使い捨て削除
 - WebAuthn は HTTPS 必須。HTTP 時はボタン非表示
 - デプロイ先 URL を issue/PR/README に含めないこと
+- **コールバックで `TokenStorage::setToken()` を使わない**（#45）。`/ecauth/callback` は
+  admin firewall の pattern (`^/%eccube_admin_route%/`) にマッチせず customer firewall (`^/`)
+  配下で処理されるため、TokenStorage に Member を載せると customer firewall の
+  `ContextListener` がレスポンス時に `_security_customer` へ書き出し、会員がマイページに
+  入れなくなる。管理者セッションは `$session->set('_security_admin', serialize($token))` で
+  確立する（リダイレクト先の管理画面リクエストで admin firewall が復元する）。
+  「Symfony の作法に合わせる」等の理由で `setToken()` に戻さないこと。
+  リグレッションテスト: `Tests/specs/passkey_auth.spec.ts` の `#45:` で始まる test

--- a/Service/PasskeyAuthService.php
+++ b/Service/PasskeyAuthService.php
@@ -10,7 +10,6 @@ use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
-use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
 class PasskeyAuthService
@@ -36,11 +35,6 @@ class PasskeyAuthService
     private $apiClient;
 
     /**
-     * @var TokenStorageInterface
-     */
-    private $tokenStorage;
-
-    /**
      * @var UserPasswordHasherInterface
      */
     private $passwordHasher;
@@ -55,7 +49,6 @@ class PasskeyAuthService
         MemberRepository $memberRepository,
         ConfigRepository $configRepository,
         EcAuthApiClient $apiClient,
-        TokenStorageInterface $tokenStorage,
         UserPasswordHasherInterface $passwordHasher,
         LoggerInterface $logger
     ) {
@@ -63,7 +56,6 @@ class PasskeyAuthService
         $this->memberRepository = $memberRepository;
         $this->configRepository = $configRepository;
         $this->apiClient = $apiClient;
-        $this->tokenStorage = $tokenStorage;
         $this->passwordHasher = $passwordHasher;
         $this->logger = $logger;
     }
@@ -205,9 +197,24 @@ class PasskeyAuthService
         }
 
         // 管理者セッション確立（セッション固定化攻撃対策）
+        //
+        // ここで TokenStorage::setToken() を呼んではいけない。
+        // コールバック URL /ecauth/callback は admin firewall の pattern
+        // (^/%eccube_admin_route%/) にマッチせず、customer firewall (^/) の配下で
+        // 処理される。TokenStorage に Member を載せると、レスポンス時に customer
+        // firewall の ContextListener::onKernelResponse() がそれを自身のセッション
+        // キーへ書き出し、_security_customer に Member のトークンが入る。
+        // ContextListener には firewall 個別ではなく全 user provider が渡るため、
+        // 以降のフロントリクエストでも MemberProvider が refreshUser() に成功し、
+        // 「ログイン済みだが ROLE_USER を持たないユーザー」としてセッションが復元される。
+        // その結果 /mypage/login はログインフォームを出さずに /mypage/ へリダイレクトし、
+        // /mypage/ は access_control の ROLE_USER を満たさず Access Denied になる。
+        //
+        // _security_admin へ直接書けば、リダイレクト先の管理画面リクエストで
+        // admin firewall の ContextListener が正しくトークンを復元するため、
+        // 管理画面へのログインは成立する。
         $session->migrate(true);
         $token = new UsernamePasswordToken($Member, 'admin', $Member->getRoles());
-        $this->tokenStorage->setToken($token);
         $session->set('_security_admin', serialize($token));
 
         $this->logger->info('EcAuth passkey authentication successful', [

--- a/Tests/specs/passkey_auth.spec.ts
+++ b/Tests/specs/passkey_auth.spec.ts
@@ -341,6 +341,39 @@ test.describe.serial('E2E: パスキー登録からログイン完了までの�
     await expect(page.locator('h2', { hasText: 'ホーム' })).toBeVisible();
   });
 
+  // リグレッション (#45): 管理者パスキーログインが customer firewall のセッションを
+  // 汚染していないことを検証する。
+  //
+  // コールバック URL /ecauth/callback は admin firewall の pattern
+  // (^/%eccube_admin_route%/) にマッチせず customer firewall (^/) 配下で処理される。
+  // handleCallback が TokenStorage に Member トークンを載せると、レスポンス時に
+  // customer firewall の ContextListener がそれを _security_customer へ書き出し、
+  // 以降フロントは「ログイン済みだが ROLE_USER を持たないユーザー」として扱う。結果:
+  //   - /mypage/login はフォームを出さず /mypage/ へリダイレクトされる
+  //   - /mypage/ は access_control の ROLE_USER を満たさず 403 (Access Denied)
+  //
+  // 同一ブラウザ (同一セッション) で検証する必要があるため、新規 context ではなく
+  // パスキーログイン済みの page をそのまま使う。
+  test('#45: 管理者パスキーログイン後もフロントの会員ログイン画面が表示される', async () => {
+    // /mypage/login はログインフォームを表示したままであること (/mypage/ へ飛ばされない)
+    const loginRes = await page.goto('/mypage/login');
+    expect(loginRes?.status()).toBe(200);
+    await expect(page).toHaveURL(/\/mypage\/login\/?$/);
+    await expect(page.locator('input[name="login_email"]')).toBeVisible();
+    await expect(page.locator('input[name="login_pass"]')).toBeVisible();
+
+    // /mypage/ は未ログイン扱いとしてログイン画面へ誘導される (Access Denied にならない)
+    const mypageRes = await page.goto('/mypage/');
+    expect(mypageRes?.status()).not.toBe(403);
+    await expect(page.locator('input[name="login_email"]')).toBeVisible();
+
+    // フロントを経由しても管理画面のセッションは維持されている
+    // (_security_admin への直接書き込みが効いていることの確認)
+    await page.goto(`${ADMIN_URL}/`);
+    await expect(page).toHaveURL(/\/admin\/?$/);
+    await expect(page.locator('h2', { hasText: 'ホーム' })).toBeVisible();
+  });
+
   // パスキーログイン直後 (session に access_token / current_credential_id が
   // 揃った状態) で /admin/ecauth/passkey/ を開き、一覧画面の各機能を検証する。
   // 別 spec として独立させると同一 staging admin (ecauth_subject UNIQUE) を


### PR DESCRIPTION
## Summary

管理画面に EcAuth パスキーでログインしたブラウザで、フロントの会員がマイページに入れなくなる問題を修正します。

コールバック URL `/ecauth/callback` は admin firewall の pattern (`^/%eccube_admin_route%/`) にマッチせず、**customer firewall (`^/`) の配下**で処理されます。`PasskeyAuthService::handleCallback()` が `TokenStorage` に Member トークンを載せると、レスポンス時に customer firewall の `ContextListener::onKernelResponse()` がそれを `_security_customer` へ書き出します。`ContextListener` には firewall 個別ではなく全 user provider が渡るため、以降のフロントリクエストでも `MemberProvider` が `refreshUser()` に成功し、「ログイン済みだが `ROLE_USER` を持たないユーザー」としてセッションが復元されていました。

結果として、そのブラウザでは以下が起きます。

- `/mypage/login` が「認証済のためログイン処理をスキップ」となりフォームを出さず `/mypage/` へリダイレクト
- `/mypage/` は access_control の `ROLE_USER` を満たさず Access Denied (403)

## Changes

- `Service/PasskeyAuthService.php`
  - `$this->tokenStorage->setToken($token);` を削除
  - 未使用になる `TokenStorageInterface` 依存（use / プロパティ / コンストラクタ引数）も削除。生成は `services.yaml` の autowire 経由のみで手動 `new` は無いため影響なし
  - 「なぜ `setToken()` を呼んではいけないか」を削除箇所にコメントで明記（将来「Symfony の作法に合わせる」等の理由で戻されないように）
- `Tests/specs/passkey_auth.spec.ts`
  - E2E リグレッションテストを追加（既存の `describe.serial` のパスキーログイン成功直後に挿入。同一セッションでないと再現しないため同じ `page` を使用）
- `CLAUDE.md`
  - 「セキュリティ注意事項」に再発防止メモを追記

管理者セッションは従来どおり `$session->set('_security_admin', serialize($token))` で確立されます。リダイレクト先の管理画面リクエストで admin firewall の `ContextListener` が復元するため、管理画面へのログインには影響しません。

## Test plan

- [x] PHP CS Fixer (dry-run, CI と同一設定) — `Found 0 of 14 files that can be fixed`
- [x] Rector (dry-run, CI と同一設定) — `[OK] Rector is done!`
- [x] `php -l Service/PasskeyAuthService.php` — syntax OK
- [x] E2E（ローカル Docker + staging EcAuth）**8 passed**
- [x] **リグレッションテストの有効性を確認**: 一時的に `setToken()` を戻した状態で実行すると、追加したテストだけが `/mypage/login` の `Expected: 200 / Received: 403` で失敗する（他の 6 テストは修正前でも pass）

追加したテストの検証内容:

- `/mypage/login` が 200 で、URL が `/mypage/login` のまま、`login_email` / `login_pass` が表示される
- `/mypage/` が 403 を返さず、ログインフォームへ誘導される
- フロント経由後も `/admin/` のセッションが維持されている（`_security_admin` 直接書き込みが効いていること＝管理画面ログインを壊していないことの担保）

## Notes

すでに汚染されたセッションは、修正後も自動的には解消しません。リクエスト開始時に `_security_customer` から Member トークンが復元され、そのまま再保存されるためです。該当ブラウザでフロントの `/logout` にアクセスするか Cookie を削除する必要があります。

より構造的な対処（コールバック URL を admin firewall 配下へ移す案）は、以下の理由で本 PR では採用していません。

- EC-CUBE の access_control (`Eccube\DependencyInjection\EccubeExtension`) は `^/{admin}/` に `ROLE_ADMIN` を要求し、匿名で到達できるのは `^/{admin}/login` 配下のみ。コールバックは未認証状態で叩かれるため、URL を `/{admin}/login/...` にする必要がある
- `redirect_uri` に `eccube_admin_route`（店舗ごとに変更が推奨される値）が埋まり、EcAuth 側への再登録運用が発生する
- B2C パスキー追加時は、Customer セッションを張る callback を customer firewall 配下に別途持つ必要があるため、その時点で 2 本立てへ整理する方が redirect_uri の再登録が一度で済む

Fixes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **不具合修正**
  * 管理者のパスキー認証後も、同一セッションで会員向け画面へ正しく遷移できるよう改善しました。
  * 未ログイン時のマイページ遷移や、認証後の管理画面セッションが維持されるよう修正しました。

* **テスト**
  * パスキー認証後の会員画面・マイページ・管理画面におけるセッション動作を検証する回帰テストを追加しました。

* **ドキュメント**
  * 認証コールバック時のセッション処理方針と関連する注意点を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->