### PR TITLE
chore(release): v1.0.2 のバージョン更新とパッケージング修正

### DIFF
--- a/.env.verify.tpl
+++ b/.env.verify.tpl
@@ -8,8 +8,9 @@
 # 使用方法（.env.tpl と併用する）:
 #   op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
 #
-# バージョンを固定したい場合は非秘密なのでインラインで渡す:
-#   ECAUTH_PLUGIN_VERSION=1.0.1 op run --env-file=.env.tpl --env-file=.env.verify.tpl -- \
+# バージョンを固定したい場合は非秘密なのでインラインで渡す（値は検証したい
+# バージョンに読み替える。省略すると最新が入る）:
+#   ECAUTH_PLUGIN_VERSION=1.0.2 op run --env-file=.env.tpl --env-file=.env.verify.tpl -- \
 #     docker compose up -d --build
 #
 # このファイルを読み込まなければ従来どおり /plugin のローカルソースからインストールされる。

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,7 +29,10 @@ jobs:
         working-directory: ../
         run: |
           rm -rf "$GITHUB_WORKSPACE/.github"
-          rm -rf "$GITHUB_WORKSPACE/tests"
+          # このリポジトリのテストは大文字の Tests/。Linux は case-sensitive なので
+          # 小文字だけ指定すると削除されず、Playwright spec が配布物に混入する。
+          # 将来 tests/ に変わっても取りこぼさないよう両方指定する。
+          rm -rf "$GITHUB_WORKSPACE/Tests" "$GITHUB_WORKSPACE/tests"
           rm -rf "$GITHUB_WORKSPACE/node_modules"
           rm -f "$GITHUB_WORKSPACE/Dockerfile"
           rm -f "$GITHUB_WORKSPACE/docker-compose.yml"
@@ -44,7 +47,10 @@ jobs:
           rm -f "$GITHUB_WORKSPACE/phpstan.neon.dist"
           rm -f "$GITHUB_WORKSPACE/rector.php"
           rm -f "$GITHUB_WORKSPACE/.php-cs-fixer.dist.php"
-          rm -f "$GITHUB_WORKSPACE/.env.tpl"
+          # 1Password テンプレートは秘密値こそ含まないが、Vault / アイテム名が
+          # 公開パッケージに載るため配布物から除外する。テンプレートが増えても
+          # 取りこぼさないようワイルドカードで消す (.env.tpl / .env.verify.tpl 等)。
+          rm -f "$GITHUB_WORKSPACE"/.env*.tpl
           rm -f "$GITHUB_WORKSPACE/CLAUDE.md"
           find "$GITHUB_WORKSPACE" -name "dummy" -delete
           find "$GITHUB_WORKSPACE" -name ".git*" -and ! -name ".gitkeep" -print0 | xargs -0 rm -rf

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,8 @@ op run --env-file=.env.tpl -- docker compose up -d --build
 op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
 
 # バージョンを固定する場合（非秘密なのでインラインで渡す）
-ECAUTH_PLUGIN_VERSION=1.0.1 \
+# 値は検証したいバージョンに読み替える。省略すると最新が入る
+ECAUTH_PLUGIN_VERSION=1.0.2 \
   op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/ecauthlogin43",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "EC-CUBE 4.2/4.3系向け EcAuth 認証プラグイン",
   "type": "eccube-plugin",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION
## Summary

v1.0.2 リリースに向けたバージョン更新と、配布パッケージに開発用ファイルが混入する問題の修正です。

## Changes

### `composer.json`

- `version` を `1.0.1` → `1.0.2`

### `.github/workflows/deploy.yml`

**1. `Tests/` が配布物に同梱されていた**

削除指定が小文字の `tests` のみで、このリポジトリの `Tests/`（大文字）にマッチしていませんでした。Linux は case-sensitive なので、公開済みの v1.0.1 tar.gz には以下が同梱されています（実物をダウンロードして確認）。

```
./Tests/.php-cs-fixer.dist.php
./Tests/rector.php
./Tests/specs/passkey_auth.spec.ts
./Tests/specs/passkey_list.spec.ts
./Tests/specs/passkey_register.spec.ts
./Tests/specs/plugin_config.spec.ts
```

将来 `tests/` にリネームされても取りこぼさないよう、両方を指定します。

**2. `.env.verify.tpl` が配布物に混入する状態だった**

`.env.tpl` のみが削除対象で、1.0.1 の後に追加された `.env.verify.tpl` は対象外でした。このままだと **v1.0.2 で初めて配布物に含まれます**。秘密値そのものは含みませんが、1Password の Vault / アイテム名が公開パッケージに載るため除外します。テンプレートが増えても取りこぼさないよう `.env*.tpl` のワイルドカードにしています。

## Test plan

`deploy.yml` はリリース公開時にしか発火しないため、パッケージング処理をローカルで再現して検証しました。

- [x] 修正後の配布物トップレベルが以下 12 エントリのみ（計 22 ファイル）になることを確認

```
Controller  Entity  Form  Repository  Resource  Service
EcAuthLoginEvent.php  EcAuthLoginNav.php  PluginManager.php
LICENSE  README.md  composer.json
```

- [x] `Tests/` / `.env.tpl` / `.env.verify.tpl` / `.github` / `docker-*` / `package.json` / `pnpm-lock.yaml` / `playwright.config.ts` / `phpstan.neon.dist` / `CLAUDE.md` / `.gitignore` がいずれも配布物に残らないことを確認
- [x] `Resource/config/services.yaml` の DI スキャンは元々 `Tests` を `exclude` しており、削除しても影響しない

## Release plan

このPRマージ後、タグ `1.0.2` / タイトル `v1.0.2` で GitHub Release を作成します（既存の 1.0.0 / 1.0.1 と同じ命名規約）。リリース公開で `deploy.yml` が発火し、tar.gz がリリースに添付されます。

v1.0.1 以降の変更のうち、配布物に影響するのは #45 の修正（PR #46）のみです。他の 3 コミットは `docker-entrypoint.sh` / `.github` / `CLAUDE.md` / `.env*.tpl` のみの変更で、いずれもパッケージから除外されます。