### PR TITLE
fix: id_token の署名・iss・aud を検証してから管理者セッションを確立する (EcAuthDocs#101)

### DIFF
--- a/.env.tpl
+++ b/.env.tpl
@@ -11,6 +11,10 @@
 # CI (.github/workflows/playwright.yml) の注入名と揃えるため CLIENT_ID /
 # CLIENT_SECRET (ECAUTH_ プレフィックスなし) を使用する。
 ECAUTH_BASE_URL=op://EcAuth/eccube4-ecauth-plugin/base_url
+# EcAuth Base URL として許可するホスト（カンマ区切り、非秘密）。
+# プラグイン既定は .ec-auth.io のみのため、Azure 上の dev / staging を使う開発時は
+# ここで明示的に許可する（EcAuthDocs #101）。
+ECAUTH_ALLOWED_HOSTS=.ec-auth.io,.azurewebsites.net
 CLIENT_ID=op://EcAuth/eccube4-ecauth-plugin/client_id
 CLIENT_SECRET=op://EcAuth/eccube4-ecauth-plugin/client_secret
 RP_ID=localhost

--- a/.env.tpl
+++ b/.env.tpl
@@ -10,11 +10,14 @@
 # EcAuth クライアント設定
 # CI (.github/workflows/playwright.yml) の注入名と揃えるため CLIENT_ID /
 # CLIENT_SECRET (ECAUTH_ プレフィックスなし) を使用する。
-ECAUTH_BASE_URL=op://EcAuth/eccube4-ecauth-plugin/base_url
 # EcAuth Base URL として許可するホスト（カンマ区切り、非秘密）。
-# プラグイン既定は .ec-auth.io のみのため、Azure 上の dev / staging を使う開発時は
-# ここで明示的に許可する（EcAuthDocs #101）。
-ECAUTH_ALLOWED_HOSTS=.ec-auth.io,.azurewebsites.net
+# プラグイン既定は .ec-auth.io のみ。ec-auth.io 配下に無い dev / staging の
+# EcAuth に繋ぐ場合は、ここに「完全なホスト名」を追記する（EcAuthDocs #101）。
+#   例: ECAUTH_ALLOWED_HOSTS=.ec-auth.io,ecauth-dev-xxxxx.example.net
+# .azurewebsites.net のようなサフィックス指定にはしないこと。共有ホスティングの
+# サフィックスを許可すると、そのサービスの全利用者を信頼することになる。
+ECAUTH_ALLOWED_HOSTS=.ec-auth.io
+ECAUTH_BASE_URL=op://EcAuth/eccube4-ecauth-plugin/base_url
 CLIENT_ID=op://EcAuth/eccube4-ecauth-plugin/client_id
 CLIENT_SECRET=op://EcAuth/eccube4-ecauth-plugin/client_secret
 RP_ID=localhost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,31 @@ jobs:
       - name: Run Rector (dry-run)
         run: vendor/bin/rector process --dry-run --config Tests/rector.php
 
+  phpunit:
+    name: PHPUnit
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # プラグインは EC-CUBE 4.2 (PHP 7.4+) から 4.3 (PHP 8.x) までを対象にするため、
+        # 下限と上限の両方でユニットテストを回して構文・API 互換を担保する。
+        php-version: ['7.4', '8.3']
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: openssl
+          tools: composer
+
+      - name: Install dependencies
+        run: composer install --no-progress --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --configuration phpunit.xml.dist
+
   cs-fixer:
     name: PHP CS Fixer
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,9 +71,12 @@ jobs:
         run: docker compose up -d --build --wait
         env:
           ECAUTH_PLUGIN_VERSION: ${{ inputs.plugin_version }}
-          # E2E は staging の EcAuth (*.azurewebsites.net) を指すため、
-          # プラグイン既定の許可ホスト (.ec-auth.io) だけでは設定を保存できない。
-          ECAUTH_ALLOWED_HOSTS: .ec-auth.io,.azurewebsites.net
+          # E2E は staging の EcAuth を指すため、プラグイン既定の許可ホスト
+          # (.ec-auth.io) だけでは設定を保存できない。
+          # .azurewebsites.net のようなサフィックス指定にはしないこと。
+          # 共有ホスティングのサフィックスを許可すると Azure の全利用者を
+          # 信頼することになり、本修正 (EcAuthDocs #101) の意味が失われる。
+          ECAUTH_ALLOWED_HOSTS: .ec-auth.io,ecauth-staging-${{ env.STAGING_WEB_APP_SUFFIX }}.azurewebsites.net
 
       - name: Wait for EC-CUBE to be ready
         run: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -71,6 +71,9 @@ jobs:
         run: docker compose up -d --build --wait
         env:
           ECAUTH_PLUGIN_VERSION: ${{ inputs.plugin_version }}
+          # E2E は staging の EcAuth (*.azurewebsites.net) を指すため、
+          # プラグイン既定の許可ホスト (.ec-auth.io) だけでは設定を保存できない。
+          ECAUTH_ALLOWED_HOSTS: .ec-auth.io,.azurewebsites.net
 
       - name: Wait for EC-CUBE to be ready
         run: |

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -5,6 +5,7 @@ namespace Plugin\EcAuthLogin43\Controller\Admin;
 use Eccube\Controller\AbstractController;
 use Plugin\EcAuthLogin43\Form\Type\Admin\ConfigType;
 use Plugin\EcAuthLogin43\Repository\ConfigRepository;
+use Plugin\EcAuthLogin43\Service\BaseUrlValidator;
 use Plugin\EcAuthLogin43\Service\ClientResolveService;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormError;
@@ -23,6 +24,11 @@ class ConfigController extends AbstractController
      * @var ClientResolveService
      */
     protected $clientResolveService;
+
+    /**
+     * @var BaseUrlValidator
+     */
+    protected $baseUrlValidator;
 
     /**
      * @var TranslatorInterface
@@ -48,12 +54,14 @@ class ConfigController extends AbstractController
     public function __construct(
         ConfigRepository $configRepository,
         ClientResolveService $clientResolveService,
+        BaseUrlValidator $baseUrlValidator,
         TranslatorInterface $translator,
         string $signupUrl,
         string $mypageUrl
     ) {
         $this->configRepository = $configRepository;
         $this->clientResolveService = $clientResolveService;
+        $this->baseUrlValidator = $baseUrlValidator;
         $this->translator = $translator;
         $this->signupUrl = $signupUrl;
         $this->mypageUrl = $mypageUrl;
@@ -95,10 +103,30 @@ class ConfigController extends AbstractController
                         'mypage_url' => $this->mypageUrl,
                     ];
                 }
-                $Config->setEcauthBaseUrl($resolved['base_url']);
+                $candidateUrl = $resolved['base_url'];
+                // client-resolve 応答も無条件には信頼しない。応答が汚染されると
+                // トークン交換先ごと攻撃者のホストに向く（EcAuthDocs #101）。
+                $errorField = 'client_id';
             } else {
-                $Config->setEcauthBaseUrl(rtrim($inputUrl, '/'));
+                $candidateUrl = $inputUrl;
+                $errorField = 'ecauth_base_url';
             }
+
+            $normalizedUrl = $this->baseUrlValidator->normalize($candidateUrl);
+            if ($normalizedUrl === null) {
+                $form->get($errorField)->addError(
+                    new FormError($this->translator->trans('ecauth_login43.admin.config.base_url.not_allowed')),
+                );
+
+                return [
+                    'form' => $form->createView(),
+                    'has_client_secret' => $hasClientSecret,
+                    'signup_url' => $this->signupUrl,
+                    'mypage_url' => $this->mypageUrl,
+                ];
+            }
+
+            $Config->setEcauthBaseUrl($normalizedUrl);
 
             $clientSecret = $form->get('client_secret')->getData();
             if ($clientSecret !== null && $clientSecret !== '') {

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -13,8 +13,10 @@ parameters:
     # client-resolve 応答の改竄で攻撃者のホストに向かないよう許可リストで縛る
     # （EcAuthDocs #101）。
     # 環境変数 ECAUTH_ALLOWED_HOSTS が設定されていればそちらが優先される。
-    # 開発・ステージング環境（*.azurewebsites.net や localhost）を使う場合は
-    # 環境変数側で明示的に追加すること。書式は BaseUrlValidator の docblock を参照。
+    # ec-auth.io 配下に無い開発・ステージング環境を使う場合は、環境変数側に
+    # 「完全なホスト名」を追加すること。共有ホスティングのサフィックス
+    # （.azurewebsites.net 等）を許可すると、そのサービスの全利用者を信頼する
+    # ことになり本検証の意味が失われる。書式は BaseUrlValidator の docblock を参照。
     ecauth_default_allowed_hosts: '.ec-auth.io'
 
 services:

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -8,6 +8,14 @@ parameters:
     # 環境変数 ECAUTH_SIGNUP_URL / ECAUTH_MYPAGE_URL が設定されていればそちらが優先される。
     ecauth_default_signup_url: 'https://ec-auth.io/signup/'
     ecauth_default_mypage_url: 'https://ec-auth.io/mypage/'
+    # EcAuth Base URL として許可するホストのリスト（カンマ区切り）。
+    # Base URL はトークン交換先かつ JWKS の取得先になるため、設定汚染や
+    # client-resolve 応答の改竄で攻撃者のホストに向かないよう許可リストで縛る
+    # （EcAuthDocs #101）。
+    # 環境変数 ECAUTH_ALLOWED_HOSTS が設定されていればそちらが優先される。
+    # 開発・ステージング環境（*.azurewebsites.net や localhost）を使う場合は
+    # 環境変数側で明示的に追加すること。書式は BaseUrlValidator の docblock を参照。
+    ecauth_default_allowed_hosts: '.ec-auth.io'
 
 services:
     Plugin\EcAuthLogin43\:
@@ -20,7 +28,19 @@ services:
             $discoveryUrl: '%env(default:ecauth_default_discovery_url:ECAUTH_CLIENT_RESOLVE_URL)%'
             $signupUrl: '%env(default:ecauth_default_signup_url:ECAUTH_SIGNUP_URL)%'
             $mypageUrl: '%env(default:ecauth_default_mypage_url:ECAUTH_MYPAGE_URL)%'
+            $allowedHosts: '%env(default:ecauth_default_allowed_hosts:ECAUTH_ALLOWED_HOSTS)%'
             $eccubeTimezone: '%timezone%'
+
+    # JWKS プロバイダ。キャッシュは EC-CUBE 本体の cache.app (PSR-6) を使う。
+    Plugin\EcAuthLogin43\Service\JwksProviderInterface:
+        alias: Plugin\EcAuthLogin43\Service\CachedJwksProvider
+
+    # resource 読み込みで登録された定義を上書きするため、autowire / autoconfigure を明示する。
+    Plugin\EcAuthLogin43\Service\CachedJwksProvider:
+        autowire: true
+        autoconfigure: true
+        arguments:
+            $cache: '@cache.app'
 
     # PSR-18 HTTP クライアント
     # EC-CUBE 4.2+ は本体が guzzlehttp/guzzle:^7 を依存として持つため Guzzle にエイリアス。

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -13,7 +13,7 @@ ecauth_login43.admin.config.signup.registered.description: 申込は不要です
 ecauth_login43.admin.config.signup.mypage.link: EcAuth マイページを開く
 ecauth_login43.admin.config.header: EcAuth 接続設定
 ecauth_login43.admin.config.ecauth_base_url: EcAuth URL
-ecauth_login43.admin.config.ecauth_base_url.help: 通常は未入力で構いません。Client ID から自動解決されます。ステージング・開発環境では直接 URL を指定できます。
+ecauth_login43.admin.config.ecauth_base_url.help: 通常は未入力で構いません。Client ID から自動解決されます。ステージング・開発環境では直接 URL を指定できますが、許可されたホスト（既定では ec-auth.io のサブドメイン）のみ登録できます。
 ecauth_login43.admin.config.client_id: Client ID
 ecauth_login43.admin.config.client_secret: Client Secret
 ecauth_login43.admin.config.rp_id: RP ID
@@ -21,6 +21,7 @@ ecauth_login43.admin.config.rp_id.help: 未設定の場合、サイトのホス�
 ecauth_login43.admin.config.advanced_settings: 高度な設定
 ecauth_login43.admin.config.advanced_settings.help: 通常は変更不要です。ステージング・開発環境や RP ID のカスタマイズが必要な場合のみ使用してください。
 ecauth_login43.admin.config.client_resolve.failed: Client ID に対応するテナントが見つかりませんでした。Client ID を確認するか、高度な設定で EcAuth URL を直接指定してください。
+ecauth_login43.admin.config.base_url.not_allowed: EcAuth URL が許可されていないホストを指しています。https で始まる正しい EcAuth の URL を指定してください。開発・ステージング環境のホストを使う場合は、環境変数 ECAUTH_ALLOWED_HOSTS に追加してください。
 ecauth_login43.admin.config.required: 必須
 ecauth_login43.admin.config.save: 登録
 ecauth_login43.admin.config.back: 戻る

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -76,14 +76,18 @@
                         </div>
                     </div>
 
+                    {# 高度な設定の中にエラーがある場合は開いた状態で描画する。
+                       折りたたんだままだとエラー文言が見えず、保存されない理由が分からなくなる
+                       （EcAuthDocs #101 で EcAuth URL の許可リスト検証を追加したため）。 #}
+                    {% set advanced_has_errors = form.ecauth_base_url.vars.errors|length > 0 or form.rp_id.vars.errors|length > 0 %}
                     <div class="card rounded border-0 mb-4">
                         <div class="card-header">
-                            <button class="btn btn-link p-0 text-decoration-none" type="button" data-bs-toggle="collapse" data-bs-target="#ecauth-advanced-settings" aria-expanded="false" aria-controls="ecauth-advanced-settings">
+                            <button class="btn btn-link p-0 text-decoration-none" type="button" data-bs-toggle="collapse" data-bs-target="#ecauth-advanced-settings" aria-expanded="{{ advanced_has_errors ? 'true' : 'false' }}" aria-controls="ecauth-advanced-settings">
                                 <i class="fa fa-caret-right me-1"></i>
                                 <span>{{ 'ecauth_login43.admin.config.advanced_settings'|trans }}</span>
                             </button>
                         </div>
-                        <div id="ecauth-advanced-settings" class="collapse">
+                        <div id="ecauth-advanced-settings" class="collapse{{ advanced_has_errors ? ' show' : '' }}">
                             <div class="card-body">
                                 <p class="form-text text-muted mb-3">{{ 'ecauth_login43.admin.config.advanced_settings.help'|trans }}</p>
                                 <div class="row mb-2">

--- a/Service/BaseUrlValidator.php
+++ b/Service/BaseUrlValidator.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Service;
+
+/**
+ * EcAuth Base URL が許可されたホストを指しているかを検証する。
+ *
+ * Base URL はトークン交換先および JWKS 取得先になるため、設定汚染や
+ * client-resolve 応答の改竄によって攻撃者のホストに向けられると、
+ * id_token の署名検証ごと攻撃者の鍵で成立してしまう。信頼の起点として
+ * ホストを許可リストで縛る。
+ *
+ * 許可リストは環境変数 ECAUTH_ALLOWED_HOSTS（カンマ区切り）で上書きできる。
+ * 各エントリの書式:
+ *
+ *   .example.com      … example.com のサブドメインすべて（apex は含まない）
+ *   example.com       … ホスト完全一致
+ *   example.com:8081  … ホストとポートの完全一致
+ *   http://localhost:8080 … 既定では https のみ許可するため、http を許す場合はスキームを明示する
+ *
+ * 許可リストが空の場合はすべて拒否する（fail-closed）。
+ */
+class BaseUrlValidator
+{
+    /**
+     * @var array<int, array{scheme: string|null, host: string, port: int|null, suffix: bool}>
+     */
+    private $allowedHosts;
+
+    public function __construct(string $allowedHosts)
+    {
+        $this->allowedHosts = $this->parseAllowedHosts($allowedHosts);
+    }
+
+    /**
+     * Base URL を検証し、正規化した URL を返す。許可されない場合は null。
+     */
+    public function normalize(?string $baseUrl): ?string
+    {
+        $baseUrl = trim((string) $baseUrl);
+        if ($baseUrl === '') {
+            return null;
+        }
+
+        $baseUrl = rtrim($baseUrl, '/');
+        $parts = parse_url($baseUrl);
+        if (!is_array($parts) || !isset($parts['scheme'], $parts['host'])) {
+            return null;
+        }
+
+        // 認証情報付き URL (https://evil@example.com) やパス・クエリ付きは受け付けない。
+        // EcAuth の Base URL は "{scheme}://{host}" の形に限られる。
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            return null;
+        }
+        if (isset($parts['path']) && $parts['path'] !== '') {
+            return null;
+        }
+        if (isset($parts['query']) || isset($parts['fragment'])) {
+            return null;
+        }
+
+        $scheme = strtolower($parts['scheme']);
+        $host = strtolower($parts['host']);
+        $port = isset($parts['port']) ? $parts['port'] : null;
+
+        if (!$this->matchesAllowedHost($scheme, $host, $port)) {
+            return null;
+        }
+
+        return $scheme.'://'.$host.($port === null ? '' : ':'.$port);
+    }
+
+    public function isAllowed(?string $baseUrl): bool
+    {
+        return $this->normalize($baseUrl) !== null;
+    }
+
+    private function matchesAllowedHost(string $scheme, string $host, ?int $port): bool
+    {
+        foreach ($this->allowedHosts as $allowed) {
+            // スキームを明示していないエントリは https のみ許可する。
+            $expectedScheme = $allowed['scheme'] ?? 'https';
+            if ($scheme !== $expectedScheme) {
+                continue;
+            }
+
+            if ($allowed['port'] !== null && $allowed['port'] !== $port) {
+                continue;
+            }
+
+            if ($allowed['suffix']) {
+                $suffix = $allowed['host'];
+                if (strlen($host) > strlen($suffix) && substr($host, -strlen($suffix)) === $suffix) {
+                    return true;
+                }
+                continue;
+            }
+
+            if ($host === $allowed['host']) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<int, array{scheme: string|null, host: string, port: int|null, suffix: bool}>
+     */
+    private function parseAllowedHosts(string $allowedHosts): array
+    {
+        $parsed = [];
+        foreach (explode(',', $allowedHosts) as $entry) {
+            $entry = strtolower(trim($entry));
+            if ($entry === '') {
+                continue;
+            }
+
+            $scheme = null;
+            if (strpos($entry, '://') !== false) {
+                [$scheme, $entry] = explode('://', $entry, 2);
+                $entry = trim($entry);
+                if ($entry === '' || ($scheme !== 'http' && $scheme !== 'https')) {
+                    continue;
+                }
+            }
+
+            $suffix = strpos($entry, '.') === 0;
+
+            $port = null;
+            // IPv6 リテラルは扱わない。ポート指定は "host:port" のみ。
+            if (preg_match('/^(.+):(\d+)$/', $entry, $matches) === 1) {
+                $entry = $matches[1];
+                $port = (int) $matches[2];
+            }
+
+            if ($entry === '.') {
+                continue;
+            }
+
+            $parsed[] = [
+                'scheme' => $scheme,
+                'host' => $entry,
+                'port' => $port,
+                'suffix' => $suffix,
+            ];
+        }
+
+        return $parsed;
+    }
+}

--- a/Service/BaseUrlValidator.php
+++ b/Service/BaseUrlValidator.php
@@ -18,7 +18,14 @@ namespace Plugin\EcAuthLogin43\Service;
  *   example.com:8081  … ホストとポートの完全一致
  *   http://localhost:8080 … 既定では https のみ許可するため、http を許す場合はスキームを明示する
  *
+ * ポートを省略したエントリはスキームの既定ポート（https なら 443）のみを許可する。
+ * 既定以外のポートを使う場合は host:port で明示すること。
+ *
  * 許可リストが空の場合はすべて拒否する（fail-closed）。
+ *
+ * ワイルドカードは可能な限り狭くすること。例えば .azurewebsites.net のような
+ * 共有ホスティングのサフィックスを許可すると、そのサービスの全利用者
+ * （＝無関係な第三者）を信頼することになり、この検証の意味が失われる。
  */
 class BaseUrlValidator
 {
@@ -62,7 +69,7 @@ class BaseUrlValidator
 
         $scheme = strtolower($parts['scheme']);
         $host = strtolower($parts['host']);
-        $port = isset($parts['port']) ? $parts['port'] : null;
+        $port = $this->normalizePort($scheme, isset($parts['port']) ? $parts['port'] : null);
 
         if (!$this->matchesAllowedHost($scheme, $host, $port)) {
             return null;
@@ -85,7 +92,10 @@ class BaseUrlValidator
                 continue;
             }
 
-            if ($allowed['port'] !== null && $allowed['port'] !== $port) {
+            // ポートを省略したエントリは「スキームの既定ポートのみ」を意味する。
+            // 省略＝任意ポート許可にすると、許可ホスト上の別サービス（例
+            // https://tenant.ec-auth.io:8443）まで信頼境界に入ってしまう。
+            if ($allowed['port'] !== $port) {
                 continue;
             }
 
@@ -142,11 +152,24 @@ class BaseUrlValidator
             $parsed[] = [
                 'scheme' => $scheme,
                 'host' => $entry,
-                'port' => $port,
+                'port' => $this->normalizePort($scheme === null ? 'https' : $scheme, $port),
                 'suffix' => $suffix,
             ];
         }
 
         return $parsed;
+    }
+
+    /**
+     * スキームの既定ポートを明示指定した場合は、省略時と同じ「null」に正規化する。
+     * https://example.com と https://example.com:443 を別物として扱わないため。
+     */
+    private function normalizePort(string $scheme, ?int $port): ?int
+    {
+        if (($scheme === 'https' && $port === 443) || ($scheme === 'http' && $port === 80)) {
+            return null;
+        }
+
+        return $port;
     }
 }

--- a/Service/CachedJwksProvider.php
+++ b/Service/CachedJwksProvider.php
@@ -2,8 +2,9 @@
 
 namespace Plugin\EcAuthLogin43\Service;
 
+use Psr\Cache\CacheException;
+use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
-use Psr\Cache\InvalidArgumentException as CacheInvalidArgumentException;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -92,10 +93,12 @@ class CachedJwksProvider implements JwksProviderInterface
 
         $cacheKey = self::CACHE_KEY_PREFIX.hash('sha256', $baseUrl);
 
+        // キャッシュはあくまで最適化なので、バックエンド障害で認証まで巻き込まない。
+        // PSR-6 の InvalidArgumentException は CacheException を継承するため、
+        // CacheException を捕捉すれば両方を吸収できる。
         try {
             $item = $this->cache->getItem($cacheKey);
-        } catch (CacheInvalidArgumentException $e) {
-            // キャッシュが使えなくても取得自体は継続する
+        } catch (CacheException $e) {
             $this->logger->warning('EcAuth JWKS cache unavailable', [
                 'error' => $e->getMessage(),
             ]);
@@ -130,9 +133,7 @@ class CachedJwksProvider implements JwksProviderInterface
             $item->expiresAfter(self::CACHE_TTL);
             // 保存に失敗しても取得自体は成立しているので続行する。ただし黙って
             // 落とすとログインのたびに JWKS を取りに行く状態に気付けないため記録する。
-            if (!$this->cache->save($item)) {
-                $this->logger->warning('Failed to cache the EcAuth JWKS');
-            }
+            $this->saveQuietly($item, 'Failed to cache the EcAuth JWKS');
         }
 
         return $keys;
@@ -150,7 +151,7 @@ class CachedJwksProvider implements JwksProviderInterface
 
         try {
             $marker = $this->cache->getItem($cooldownKey);
-        } catch (CacheInvalidArgumentException $e) {
+        } catch (CacheException $e) {
             // クールダウンを管理できない場合は従来どおり再取得を許可する
             return true;
         }
@@ -163,9 +164,34 @@ class CachedJwksProvider implements JwksProviderInterface
 
         $marker->set(true);
         $marker->expiresAfter(self::FORCED_REFRESH_COOLDOWN);
-        $this->cache->save($marker);
+        // マーカーを保存できないとクールダウンが機能しない（＝ 強制再取得を
+        // 抑制できない）。取得自体は許可するが、抑制が効いていないことを残す。
+        $this->saveQuietly($marker, 'Failed to record the EcAuth JWKS refresh cooldown');
 
         return true;
+    }
+
+    /**
+     * キャッシュへの保存はベストエフォートで行う。
+     *
+     * JWKS の取得自体は成功しているため、キャッシュバックエンドの障害
+     * （false 返却・CacheException のいずれも）で認証処理まで巻き込まない。
+     */
+    private function saveQuietly(CacheItemInterface $item, string $failureMessage): bool
+    {
+        try {
+            if ($this->cache->save($item)) {
+                return true;
+            }
+        } catch (CacheException $e) {
+            $this->logger->warning($failureMessage, ['error' => $e->getMessage()]);
+
+            return false;
+        }
+
+        $this->logger->warning($failureMessage);
+
+        return false;
     }
 
     /**

--- a/Service/CachedJwksProvider.php
+++ b/Service/CachedJwksProvider.php
@@ -102,7 +102,11 @@ class CachedJwksProvider implements JwksProviderInterface
         if ($item !== null) {
             $item->set($keys);
             $item->expiresAfter(self::CACHE_TTL);
-            $this->cache->save($item);
+            // 保存に失敗しても取得自体は成立しているので続行する。ただし黙って
+            // 落とすとログインのたびに JWKS を取りに行く状態に気付けないため記録する。
+            if (!$this->cache->save($item)) {
+                $this->logger->warning('Failed to cache the EcAuth JWKS');
+            }
         }
 
         return $keys;

--- a/Service/CachedJwksProvider.php
+++ b/Service/CachedJwksProvider.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Service;
+
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException as CacheInvalidArgumentException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * EcAuth の JWKS エンドポイント（{base_url}/.well-known/jwks.json）から
+ * 公開鍵を取得し、PSR-6 キャッシュに一定時間保持する。
+ *
+ * JWKS は Organization（テナント）ごとに異なるため、キャッシュキーは Base URL から導出する。
+ */
+class CachedJwksProvider implements JwksProviderInterface
+{
+    private const JWKS_PATH = '/.well-known/jwks.json';
+
+    /**
+     * キャッシュキーの接頭辞。PSR-6 の予約文字 {}()/\@: を含めないこと。
+     */
+    private const CACHE_KEY_PREFIX = 'ecauth_jwks_';
+
+    /**
+     * JWKS のキャッシュ保持秒数。
+     *
+     * 短すぎるとログインのたびに EcAuth へ HTTP リクエストが飛び、長すぎると
+     * 鍵ローテーション直後の追従が遅れる。kid 不一致時は forceRefresh で
+     * 即時再取得されるため、通常運用ではこの TTL が追従性の上限にはならない。
+     */
+    private const CACHE_TTL = 300;
+
+    /**
+     * @var ClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var RequestFactoryInterface
+     */
+    private $requestFactory;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(
+        ClientInterface $httpClient,
+        RequestFactoryInterface $requestFactory,
+        CacheItemPoolInterface $cache,
+        LoggerInterface $logger
+    ) {
+        $this->httpClient = $httpClient;
+        $this->requestFactory = $requestFactory;
+        $this->cache = $cache;
+        $this->logger = $logger;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJwks(string $baseUrl, bool $forceRefresh = false): ?array
+    {
+        $baseUrl = rtrim($baseUrl, '/');
+        if ($baseUrl === '') {
+            return null;
+        }
+
+        $cacheKey = self::CACHE_KEY_PREFIX.hash('sha256', $baseUrl);
+
+        try {
+            $item = $this->cache->getItem($cacheKey);
+        } catch (CacheInvalidArgumentException $e) {
+            // キャッシュが使えなくても取得自体は継続する
+            $this->logger->warning('EcAuth JWKS cache unavailable', [
+                'error' => $e->getMessage(),
+            ]);
+            $item = null;
+        }
+
+        if (!$forceRefresh && $item !== null && $item->isHit()) {
+            $cached = $item->get();
+            if (is_array($cached) && $cached !== []) {
+                return $cached;
+            }
+        }
+
+        $keys = $this->fetch($baseUrl);
+        if ($keys === null) {
+            return null;
+        }
+
+        if ($item !== null) {
+            $item->set($keys);
+            $item->expiresAfter(self::CACHE_TTL);
+            $this->cache->save($item);
+        }
+
+        return $keys;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function fetch(string $baseUrl): ?array
+    {
+        $request = $this->requestFactory
+            ->createRequest('GET', $baseUrl.self::JWKS_PATH)
+            ->withHeader('Accept', 'application/json');
+
+        try {
+            $response = $this->httpClient->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            $this->logger->error('EcAuth JWKS request failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
+
+        $statusCode = $response->getStatusCode();
+        if ($statusCode !== 200) {
+            $this->logger->error('EcAuth JWKS endpoint returned an error', [
+                'status' => $statusCode,
+            ]);
+
+            return null;
+        }
+
+        $decoded = json_decode((string) $response->getBody(), true);
+        if (!is_array($decoded) || !isset($decoded['keys']) || !is_array($decoded['keys'])) {
+            $this->logger->error('EcAuth JWKS response is malformed');
+
+            return null;
+        }
+
+        $keys = [];
+        foreach ($decoded['keys'] as $key) {
+            if (is_array($key)) {
+                $keys[] = $key;
+            }
+        }
+
+        if ($keys === []) {
+            $this->logger->error('EcAuth JWKS response contains no usable key');
+
+            return null;
+        }
+
+        return $keys;
+    }
+}

--- a/Service/CachedJwksProvider.php
+++ b/Service/CachedJwksProvider.php
@@ -34,6 +34,21 @@ class CachedJwksProvider implements JwksProviderInterface
     private const CACHE_TTL = 300;
 
     /**
+     * 強制再取得（kid 不一致時）を許可する最短間隔（秒）。
+     *
+     * kid は id_token のヘッダから来るため、kid を変え続けるトークンを渡されると
+     * キャッシュを迂回して JWKS エンドポイントへのリクエストを増幅できてしまう。
+     * EcAuth 側の設定ミスで「JWKS に無い kid」が発行され続ける状況でも、
+     * ログインのたびに 2 回 HTTP を叩くことになる。クールダウンで上限を設ける。
+     */
+    private const FORCED_REFRESH_COOLDOWN = 60;
+
+    /**
+     * クールダウン中であることを示すマーカーのキー接頭辞。
+     */
+    private const COOLDOWN_KEY_PREFIX = 'ecauth_jwks_forced_';
+
+    /**
      * @var ClientInterface
      */
     private $httpClient;
@@ -87,11 +102,22 @@ class CachedJwksProvider implements JwksProviderInterface
             $item = null;
         }
 
-        if (!$forceRefresh && $item !== null && $item->isHit()) {
-            $cached = $item->get();
-            if (is_array($cached) && $cached !== []) {
-                return $cached;
+        $cached = null;
+        if ($item !== null && $item->isHit()) {
+            $hit = $item->get();
+            if (is_array($hit) && $hit !== []) {
+                $cached = $hit;
             }
+        }
+
+        if (!$forceRefresh && $cached !== null) {
+            return $cached;
+        }
+
+        // 直近に強制再取得したばかりなら、キャッシュを返して外部リクエストを抑える。
+        // キャッシュが空のときは返せるものが無いので取得を許可する。
+        if ($forceRefresh && $cached !== null && !$this->tryConsumeForcedRefresh($baseUrl)) {
+            return $cached;
         }
 
         $keys = $this->fetch($baseUrl);
@@ -110,6 +136,36 @@ class CachedJwksProvider implements JwksProviderInterface
         }
 
         return $keys;
+    }
+
+    /**
+     * 強制再取得のクールダウンを消費する。
+     *
+     * まだクールダウン中なら false を返し、呼び出し側は再取得を見送る。
+     * 許可した場合はマーカーを立てて、次の呼び出しから一定時間ブロックする。
+     */
+    private function tryConsumeForcedRefresh(string $baseUrl): bool
+    {
+        $cooldownKey = self::COOLDOWN_KEY_PREFIX.hash('sha256', $baseUrl);
+
+        try {
+            $marker = $this->cache->getItem($cooldownKey);
+        } catch (CacheInvalidArgumentException $e) {
+            // クールダウンを管理できない場合は従来どおり再取得を許可する
+            return true;
+        }
+
+        if ($marker->isHit()) {
+            $this->logger->warning('Skipping the forced EcAuth JWKS refresh; still in cooldown');
+
+            return false;
+        }
+
+        $marker->set(true);
+        $marker->expiresAfter(self::FORCED_REFRESH_COOLDOWN);
+        $this->cache->save($marker);
+
+        return true;
     }
 
     /**

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -33,6 +33,11 @@ class EcAuthApiClient
     private $streamFactory;
 
     /**
+     * @var BaseUrlValidator
+     */
+    private $baseUrlValidator;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -42,12 +47,14 @@ class EcAuthApiClient
         ClientInterface $httpClient,
         RequestFactoryInterface $requestFactory,
         StreamFactoryInterface $streamFactory,
+        BaseUrlValidator $baseUrlValidator,
         LoggerInterface $logger
     ) {
         $this->configRepository = $configRepository;
         $this->httpClient = $httpClient;
         $this->requestFactory = $requestFactory;
         $this->streamFactory = $streamFactory;
+        $this->baseUrlValidator = $baseUrlValidator;
         $this->logger = $logger;
     }
 
@@ -189,11 +196,29 @@ class EcAuthApiClient
         return $Config ? $Config->getClientSecret() ?? '' : '';
     }
 
+    /**
+     * 許可リストを通った Base URL のみを返す。許可されない場合は空文字を返し、
+     * 呼び出し側でリクエストを中止させる。
+     *
+     * 設定画面での保存時にも検証しているが、DB を直接書き換えられた場合や
+     * 許可リストを狭めた後に古い値が残っている場合に備え、実行時にも再検証する
+     * （EcAuthDocs #101）。
+     */
     private function getBaseUrl(): string
     {
         $Config = $this->configRepository->get();
+        if ($Config === null) {
+            return '';
+        }
 
-        return $Config ? rtrim($Config->getEcauthBaseUrl() ?? '', '/') : '';
+        $baseUrl = $this->baseUrlValidator->normalize($Config->getEcauthBaseUrl());
+        if ($baseUrl === null) {
+            $this->logger->error('EcAuth Base URL is not allowed');
+
+            return '';
+        }
+
+        return $baseUrl;
     }
 
     /**

--- a/Service/EcAuthApiClient.php
+++ b/Service/EcAuthApiClient.php
@@ -211,7 +211,15 @@ class EcAuthApiClient
             return '';
         }
 
-        $baseUrl = $this->baseUrlValidator->normalize($Config->getEcauthBaseUrl());
+        // 未設定（プラグイン導入直後）と「設定されているが許可されていない」は
+        // 運用上まったく別の事象なので、前者をここで警告にしない。
+        // 未設定の場合は呼び出し側が "not configured" を記録する。
+        $configured = trim((string) ($Config->getEcauthBaseUrl() ?? ''));
+        if ($configured === '') {
+            return '';
+        }
+
+        $baseUrl = $this->baseUrlValidator->normalize($configured);
         if ($baseUrl === null) {
             $this->logger->error('EcAuth Base URL is not allowed');
 

--- a/Service/IdTokenVerifier.php
+++ b/Service/IdTokenVerifier.php
@@ -13,8 +13,8 @@ use Psr\Log\LoggerInterface;
  * 検証内容:
  *   1. JWT ヘッダの alg が RS256 であること（alg=none / HS256 への差し替え拒否）
  *   2. JWKS ({base_url}/.well-known/jwks.json) の公開鍵による RS256 署名検証
- *   3. iss が設定済み Base URL と一致すること
- *   4. aud が自身の client_id と一致すること
+ *   3. iss が設定済み Base URL と完全一致すること
+ *   4. aud が自身の client_id を含むこと、および azp（あれば）が自身であること
  *   5. exp が存在し、有効期限内であること（exp 欠落トークンは拒否）
  *   6. nbf / iat が存在する場合、それらが未来でないこと
  *
@@ -237,16 +237,24 @@ class IdTokenVerifier
      */
     private function validateClaims(array $payload, string $expectedIssuer, string $expectedAudience): bool
     {
-        $issuer = isset($payload['iss']) && is_string($payload['iss']) ? rtrim($payload['iss'], '/') : '';
+        // OIDC Core 3.1.3.7 (2): iss は完全一致で比較する。末尾スラッシュ等を
+        // 吸収してしまうと、末尾スラッシュだけが異なる別 issuer のトークンを
+        // 受け入れてしまう。設定値側は BaseUrlValidator で正規化済み。
+        $issuer = isset($payload['iss']) && is_string($payload['iss']) ? $payload['iss'] : '';
         if (!hash_equals($expectedIssuer, $issuer)) {
             $this->logger->warning('ID token issuer mismatch');
 
             return false;
         }
 
-        if (!$this->audienceMatches($payload['aud'] ?? null, $expectedAudience)) {
+        $audience = $payload['aud'] ?? null;
+        if (!$this->audienceMatches($audience, $expectedAudience)) {
             $this->logger->warning('ID token audience mismatch');
 
+            return false;
+        }
+
+        if (!$this->authorizedPartyMatches($payload, $audience, $expectedAudience)) {
             return false;
         }
 
@@ -272,6 +280,44 @@ class IdTokenVerifier
 
         if (isset($payload['iat']) && (!$this->isTimestamp($payload['iat']) || (int) $payload['iat'] > $now + self::CLOCK_SKEW)) {
             $this->logger->warning('ID token was issued in the future');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * azp（Authorized Party）を検証する。
+     *
+     * OIDC Core 3.1.3.7 (4)(5):
+     *   - aud が複数ある場合、azp の存在を確認しなければならない
+     *   - azp がある場合、その値が自身の client_id と一致することを確認しなければならない
+     *
+     * aud に自分が含まれてさえいれば通す実装だと、別クライアント向けに発行された
+     * （issuer の署名が正当な）トークンを使い回して管理者セッションを確立できてしまう。
+     *
+     * @param array<string, mixed> $payload
+     * @param mixed $audience
+     */
+    private function authorizedPartyMatches(array $payload, $audience, string $expectedAudience): bool
+    {
+        $azp = $payload['azp'] ?? null;
+
+        if ($azp !== null) {
+            if (!is_string($azp) || !hash_equals($expectedAudience, $azp)) {
+                $this->logger->warning('ID token azp does not identify this client');
+
+                return false;
+            }
+
+            return true;
+        }
+
+        // aud が複数あるのに azp が無いと、どのクライアント向けに発行された
+        // トークンなのか判別できない。
+        if (is_array($audience) && count($audience) > 1) {
+            $this->logger->warning('ID token has multiple audiences but no azp claim');
 
             return false;
         }

--- a/Service/IdTokenVerifier.php
+++ b/Service/IdTokenVerifier.php
@@ -1,0 +1,409 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Service;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * EcAuth が発行した id_token (JWT) を検証する。
+ *
+ * 本クラスは「管理者セッションを確立してよいか」の判断の起点になるため、
+ * 検証に少しでも失敗した場合は必ず null を返す（fail-closed）。
+ *
+ * 検証内容:
+ *   1. JWT ヘッダの alg が RS256 であること（alg=none / HS256 への差し替え拒否）
+ *   2. JWKS ({base_url}/.well-known/jwks.json) の公開鍵による RS256 署名検証
+ *   3. iss が設定済み Base URL と一致すること
+ *   4. aud が自身の client_id と一致すること
+ *   5. exp が存在し、有効期限内であること（exp 欠落トークンは拒否）
+ *   6. nbf / iat が存在する場合、それらが未来でないこと
+ *
+ * EcAuth 側の実装は RS256 固定（TokenService）、issuer は "{scheme}://{host}"
+ * （IssuerResolver、末尾スラッシュなし）、aud は client_id。
+ *
+ * 署名検証そのものは OpenSSL に委譲し、本クラスでは JWK (n, e) から
+ * SubjectPublicKeyInfo の DER を組み立てて PEM 化する処理のみを持つ。
+ */
+class IdTokenVerifier
+{
+    /**
+     * 許容する署名アルゴリズム。EcAuth は RS256 固定で発行する。
+     * ここを緩めると alg confusion 攻撃の余地が生まれるため、他の値は受け付けない。
+     */
+    private const REQUIRED_ALG = 'RS256';
+
+    /**
+     * 時刻クレーム比較時に許容するずれ（秒）。EC-CUBE サーバーと EcAuth の
+     * 時刻同期ずれを吸収するための最小限の値。
+     */
+    private const CLOCK_SKEW = 60;
+
+    /**
+     * OID 1.2.840.113549.1.1.1 (rsaEncryption) の DER エンコード。
+     */
+    private const OID_RSA_ENCRYPTION = "\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01";
+
+    /**
+     * @var JwksProviderInterface
+     */
+    private $jwksProvider;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    public function __construct(JwksProviderInterface $jwksProvider, LoggerInterface $logger)
+    {
+        $this->jwksProvider = $jwksProvider;
+        $this->logger = $logger;
+    }
+
+    /**
+     * id_token を検証し、検証済みのペイロード（クレーム）を返す。
+     *
+     * @param string $idToken 検証対象の id_token (JWT)
+     * @param string $expectedIssuer 期待する iss（＝ EcAuth Base URL、末尾スラッシュなし）
+     * @param string $expectedAudience 期待する aud（＝ 自身の client_id）
+     *
+     * @return array<string, mixed>|null 検証成功時はペイロード、失敗時は null
+     */
+    public function verify(string $idToken, string $expectedIssuer, string $expectedAudience): ?array
+    {
+        $expectedIssuer = rtrim($expectedIssuer, '/');
+        if ($expectedIssuer === '' || $expectedAudience === '') {
+            $this->logger->error('ID token verification skipped: issuer or audience is not configured');
+
+            return null;
+        }
+
+        $parts = explode('.', $idToken);
+        if (count($parts) !== 3) {
+            $this->logger->warning('ID token is not a well-formed JWT');
+
+            return null;
+        }
+
+        $header = $this->decodeJsonSegment($parts[0]);
+        $payload = $this->decodeJsonSegment($parts[1]);
+        $signature = $this->base64UrlDecode($parts[2]);
+
+        if ($header === null || $payload === null || $signature === null || $signature === '') {
+            $this->logger->warning('ID token segments could not be decoded');
+
+            return null;
+        }
+
+        $alg = isset($header['alg']) && is_string($header['alg']) ? $header['alg'] : '';
+        if (!hash_equals(self::REQUIRED_ALG, $alg)) {
+            // alg=none や HS256 への差し替えはここで落とす
+            $this->logger->warning('ID token uses an unsupported signing algorithm', [
+                'alg' => $alg,
+            ]);
+
+            return null;
+        }
+
+        $kid = isset($header['kid']) && is_string($header['kid']) && $header['kid'] !== ''
+            ? $header['kid']
+            : null;
+
+        $signingInput = $parts[0].'.'.$parts[1];
+        if (!$this->verifySignature($signingInput, $signature, $expectedIssuer, $kid)) {
+            return null;
+        }
+
+        if (!$this->validateClaims($payload, $expectedIssuer, $expectedAudience)) {
+            return null;
+        }
+
+        if (!isset($payload['sub']) || !is_string($payload['sub']) || $payload['sub'] === '') {
+            $this->logger->warning('ID token has no usable sub claim');
+
+            return null;
+        }
+
+        return $payload;
+    }
+
+    /**
+     * 現在時刻。テストから差し替えられるように分離している。
+     */
+    protected function now(): int
+    {
+        return time();
+    }
+
+    /**
+     * JWKS の公開鍵で署名を検証する。
+     */
+    private function verifySignature(string $signingInput, string $signature, string $issuer, ?string $kid): bool
+    {
+        $jwks = $this->jwksProvider->getJwks($issuer, false);
+        $key = $jwks === null ? null : $this->selectKey($jwks, $kid);
+
+        if ($key === null) {
+            // 鍵が見つからないのはキャッシュが古い（鍵ローテーション直後）可能性がある。
+            // 署名検証の失敗ではないため、ここでだけ強制再取得を 1 度試みる。
+            $jwks = $this->jwksProvider->getJwks($issuer, true);
+            $key = $jwks === null ? null : $this->selectKey($jwks, $kid);
+        }
+
+        if ($key === null) {
+            $this->logger->warning('No matching JWK found for ID token', [
+                'kid' => $kid,
+            ]);
+
+            return false;
+        }
+
+        $modulus = $this->base64UrlDecode((string) $key['n']);
+        $exponent = $this->base64UrlDecode((string) $key['e']);
+        if ($modulus === null || $exponent === null || $modulus === '' || $exponent === '') {
+            $this->logger->error('JWK contains a malformed RSA public key');
+
+            return false;
+        }
+
+        $publicKey = openssl_pkey_get_public($this->rsaPublicKeyToPem($modulus, $exponent));
+        if ($publicKey === false) {
+            $this->logger->error('Failed to build an OpenSSL public key from JWK');
+
+            return false;
+        }
+
+        $result = openssl_verify($signingInput, $signature, $publicKey, OPENSSL_ALGO_SHA256);
+        if ($result !== 1) {
+            $this->logger->warning('ID token signature verification failed', [
+                'openssl_verify' => $result,
+            ]);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * 署名検証に使える JWK を選択する。
+     *
+     * kid がトークンヘッダにある場合は kid 一致を必須とする。kid が無い場合に限り、
+     * 候補が 1 件だけならそれを使う（EcAuth 側の鍵ローテーション未実装時の互換措置）。
+     *
+     * @param array<int, array<string, mixed>> $jwks
+     *
+     * @return array<string, mixed>|null
+     */
+    private function selectKey(array $jwks, ?string $kid): ?array
+    {
+        $candidates = [];
+        foreach ($jwks as $key) {
+            if (!is_array($key)) {
+                continue;
+            }
+            if (!isset($key['kty']) || $key['kty'] !== 'RSA') {
+                continue;
+            }
+            // use / alg は省略可。指定がある場合のみ厳格に一致を要求する。
+            if (isset($key['use']) && $key['use'] !== 'sig') {
+                continue;
+            }
+            if (isset($key['alg']) && $key['alg'] !== self::REQUIRED_ALG) {
+                continue;
+            }
+            if (!isset($key['n'], $key['e']) || !is_string($key['n']) || !is_string($key['e'])) {
+                continue;
+            }
+            $candidates[] = $key;
+        }
+
+        if ($kid !== null) {
+            foreach ($candidates as $key) {
+                if (isset($key['kid']) && is_string($key['kid']) && hash_equals($key['kid'], $kid)) {
+                    return $key;
+                }
+            }
+
+            return null;
+        }
+
+        return count($candidates) === 1 ? $candidates[0] : null;
+    }
+
+    /**
+     * iss / aud / exp / nbf / iat を検証する。
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function validateClaims(array $payload, string $expectedIssuer, string $expectedAudience): bool
+    {
+        $issuer = isset($payload['iss']) && is_string($payload['iss']) ? rtrim($payload['iss'], '/') : '';
+        if (!hash_equals($expectedIssuer, $issuer)) {
+            $this->logger->warning('ID token issuer mismatch');
+
+            return false;
+        }
+
+        if (!$this->audienceMatches($payload['aud'] ?? null, $expectedAudience)) {
+            $this->logger->warning('ID token audience mismatch');
+
+            return false;
+        }
+
+        $now = $this->now();
+
+        // exp は必須。欠落トークンを通すと期限切れトークンの再利用を許してしまう。
+        if (!isset($payload['exp']) || !$this->isTimestamp($payload['exp'])) {
+            $this->logger->warning('ID token has no valid exp claim');
+
+            return false;
+        }
+        if ((int) $payload['exp'] <= $now - self::CLOCK_SKEW) {
+            $this->logger->warning('ID token is expired');
+
+            return false;
+        }
+
+        if (isset($payload['nbf']) && (!$this->isTimestamp($payload['nbf']) || (int) $payload['nbf'] > $now + self::CLOCK_SKEW)) {
+            $this->logger->warning('ID token is not yet valid');
+
+            return false;
+        }
+
+        if (isset($payload['iat']) && (!$this->isTimestamp($payload['iat']) || (int) $payload['iat'] > $now + self::CLOCK_SKEW)) {
+            $this->logger->warning('ID token was issued in the future');
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * aud クレームを検証する。単一文字列と配列のどちらの表現にも対応する。
+     *
+     * @param mixed $aud
+     */
+    private function audienceMatches($aud, string $expectedAudience): bool
+    {
+        if (is_string($aud)) {
+            return hash_equals($expectedAudience, $aud);
+        }
+
+        if (is_array($aud)) {
+            foreach ($aud as $value) {
+                if (is_string($value) && hash_equals($expectedAudience, $value)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    private function isTimestamp($value): bool
+    {
+        return is_int($value) || (is_string($value) && ctype_digit($value)) || is_float($value);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeJsonSegment(string $segment): ?array
+    {
+        $decoded = $this->base64UrlDecode($segment);
+        if ($decoded === null) {
+            return null;
+        }
+
+        $json = json_decode($decoded, true);
+
+        return is_array($json) ? $json : null;
+    }
+
+    private function base64UrlDecode(string $input): ?string
+    {
+        $remainder = strlen($input) % 4;
+        if ($remainder !== 0) {
+            $input .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode(strtr($input, '-_', '+/'), true);
+
+        return $decoded === false ? null : $decoded;
+    }
+
+    /**
+     * RSA の modulus (n) と exponent (e) から PEM 形式の公開鍵を組み立てる。
+     *
+     * PHP には JWK → PEM の標準関数が無いため、X.509 SubjectPublicKeyInfo の
+     * DER を手で組み立てる。構造は RFC 5280 / RFC 8017 に従う:
+     *
+     *   SEQUENCE {
+     *     SEQUENCE { OBJECT IDENTIFIER rsaEncryption, NULL }
+     *     BIT STRING { SEQUENCE { INTEGER n, INTEGER e } }
+     *   }
+     */
+    private function rsaPublicKeyToPem(string $modulus, string $exponent): string
+    {
+        $rsaPublicKey = $this->derSequence(
+            $this->derInteger($modulus).$this->derInteger($exponent),
+        );
+
+        $algorithmIdentifier = $this->derSequence(
+            "\x06".$this->derLength(strlen(self::OID_RSA_ENCRYPTION)).self::OID_RSA_ENCRYPTION."\x05\x00",
+        );
+
+        // BIT STRING の先頭 1 バイトは「未使用ビット数」。バイト境界なので常に 0。
+        $bitString = "\x03".$this->derLength(strlen($rsaPublicKey) + 1)."\x00".$rsaPublicKey;
+
+        $der = $this->derSequence($algorithmIdentifier.$bitString);
+
+        return "-----BEGIN PUBLIC KEY-----\n"
+            .chunk_split(base64_encode($der), 64, "\n")
+            ."-----END PUBLIC KEY-----\n";
+    }
+
+    private function derSequence(string $content): string
+    {
+        return "\x30".$this->derLength(strlen($content)).$content;
+    }
+
+    /**
+     * DER の INTEGER を組み立てる。DER の INTEGER は符号付きなので、最上位ビットが
+     * 立っている場合は正の数であることを示す 0x00 を前置する。
+     */
+    private function derInteger(string $raw): string
+    {
+        $raw = ltrim($raw, "\x00");
+        if ($raw === '') {
+            $raw = "\x00";
+        }
+        if ((ord($raw[0]) & 0x80) !== 0) {
+            $raw = "\x00".$raw;
+        }
+
+        return "\x02".$this->derLength(strlen($raw)).$raw;
+    }
+
+    /**
+     * DER の長さフィールドを組み立てる（127 バイト以下は短形式、それ以上は長形式）。
+     */
+    private function derLength(int $length): string
+    {
+        if ($length < 0x80) {
+            return chr($length);
+        }
+
+        $bytes = '';
+        while ($length > 0) {
+            $bytes = chr($length & 0xff).$bytes;
+            $length >>= 8;
+        }
+
+        return chr(0x80 | strlen($bytes)).$bytes;
+    }
+}

--- a/Service/JwksProviderInterface.php
+++ b/Service/JwksProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Service;
+
+/**
+ * EcAuth の JWKS (JSON Web Key Set) を取得する抽象。
+ *
+ * 実装は取得結果をキャッシュしてよいが、$forceRefresh = true の場合は
+ * キャッシュを無視して再取得しなければならない（鍵ローテーション追従のため）。
+ */
+interface JwksProviderInterface
+{
+    /**
+     * @param string $baseUrl EcAuth の Base URL（末尾スラッシュなし）
+     * @param bool $forceRefresh キャッシュを無視して再取得する
+     *
+     * @return array<int, array<string, mixed>>|null JWK の配列。取得失敗時は null
+     */
+    public function getJwks(string $baseUrl, bool $forceRefresh = false): ?array;
+}

--- a/Service/PasskeyAuthService.php
+++ b/Service/PasskeyAuthService.php
@@ -369,7 +369,14 @@ class PasskeyAuthService
             return null;
         }
 
-        $baseUrl = $this->baseUrlValidator->normalize($Config->getEcauthBaseUrl());
+        $configured = trim((string) ($Config->getEcauthBaseUrl() ?? ''));
+        if ($configured === '') {
+            $this->logger->error('EcAuth Base URL is not configured; refusing to verify ID token');
+
+            return null;
+        }
+
+        $baseUrl = $this->baseUrlValidator->normalize($configured);
         if ($baseUrl === null) {
             $this->logger->error('EcAuth Base URL is not allowed; refusing to verify ID token');
 

--- a/Service/PasskeyAuthService.php
+++ b/Service/PasskeyAuthService.php
@@ -40,6 +40,16 @@ class PasskeyAuthService
     private $passwordHasher;
 
     /**
+     * @var IdTokenVerifier
+     */
+    private $idTokenVerifier;
+
+    /**
+     * @var BaseUrlValidator
+     */
+    private $baseUrlValidator;
+
+    /**
      * @var LoggerInterface
      */
     private $logger;
@@ -50,6 +60,8 @@ class PasskeyAuthService
         ConfigRepository $configRepository,
         EcAuthApiClient $apiClient,
         UserPasswordHasherInterface $passwordHasher,
+        IdTokenVerifier $idTokenVerifier,
+        BaseUrlValidator $baseUrlValidator,
         LoggerInterface $logger
     ) {
         $this->entityManager = $entityManager;
@@ -57,6 +69,8 @@ class PasskeyAuthService
         $this->configRepository = $configRepository;
         $this->apiClient = $apiClient;
         $this->passwordHasher = $passwordHasher;
+        $this->idTokenVerifier = $idTokenVerifier;
+        $this->baseUrlValidator = $baseUrlValidator;
         $this->logger = $logger;
     }
 
@@ -158,9 +172,9 @@ class PasskeyAuthService
             return null;
         }
 
-        $b2bSubject = $this->extractSubFromIdToken($idToken);
+        $b2bSubject = $this->verifyIdTokenAndExtractSub($idToken);
         if ($b2bSubject === null) {
-            $this->logger->error('Failed to extract sub from id_token');
+            $this->logger->error('ID token verification failed');
 
             return null;
         }
@@ -339,30 +353,37 @@ class PasskeyAuthService
     }
 
     /**
-     * ID Token (JWT) から sub クレームを取得する。
-     * 署名検証は EcAuth 側で実施済みのため、ペイロードのデコードのみ行う。
+     * ID Token (JWT) を検証し、sub クレームを取得する。
+     *
+     * sub はこの後 Member の引き当てと管理者セッション確立に直結するため、
+     * 署名・iss・aud・exp をすべて検証してからでなければ採用してはいけない
+     * （EcAuthDocs #101）。Base URL は JWKS の取得先と iss の期待値の両方に
+     * なるので、許可リストを通ったものだけを信頼の起点にする。
      */
-    private function extractSubFromIdToken(string $idToken): ?string
+    private function verifyIdTokenAndExtractSub(string $idToken): ?string
     {
-        $parts = explode('.', $idToken);
-        if (count($parts) !== 3) {
-            return null;
-        }
-
-        $payloadB64 = strtr($parts[1], '-_', '+/');
-        $payloadB64 = str_pad($payloadB64, (int) ceil(strlen($payloadB64) / 4) * 4, '=');
-        $payload = json_decode(base64_decode($payloadB64), true);
-        if (!is_array($payload) || !isset($payload['sub'])) {
-            return null;
-        }
-
-        if (isset($payload['exp']) && $payload['exp'] < time()) {
-            $this->logger->warning('ID token expired');
+        $Config = $this->configRepository->get();
+        if ($Config === null) {
+            $this->logger->error('EcAuth config is not available');
 
             return null;
         }
 
-        return $payload['sub'];
+        $baseUrl = $this->baseUrlValidator->normalize($Config->getEcauthBaseUrl());
+        if ($baseUrl === null) {
+            $this->logger->error('EcAuth Base URL is not allowed; refusing to verify ID token');
+
+            return null;
+        }
+
+        $clientId = (string) ($Config->getClientId() ?? '');
+
+        $payload = $this->idTokenVerifier->verify($idToken, $baseUrl, $clientId);
+        if ($payload === null) {
+            return null;
+        }
+
+        return (string) $payload['sub'];
     }
 
     private function generateUuidV4(): string

--- a/Tests/.php-cs-fixer.dist.php
+++ b/Tests/.php-cs-fixer.dist.php
@@ -9,6 +9,7 @@ $finder = PhpCsFixer\Finder::create()
         __DIR__.'/../Form',
         __DIR__.'/../Repository',
         __DIR__.'/../Service',
+        __DIR__.'/Unit',
     ])
     ->append([
         __DIR__.'/../EcAuthLoginEvent.php',

--- a/Tests/Unit/BaseUrlValidatorTest.php
+++ b/Tests/Unit/BaseUrlValidatorTest.php
@@ -61,12 +61,33 @@ class BaseUrlValidatorTest extends TestCase
         self::assertNull($validator->normalize('https://localhost'));
     }
 
+    public function testEntryWithoutPortAllowsOnlyTheDefaultPort(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        // 許可ホスト上の別サービスまで信頼境界に入れない
+        self::assertNull($validator->normalize('https://tenant.ec-auth.io:8443'));
+        // 既定ポートの明示指定は省略時と同一視し、正規化して落とす
+        self::assertSame('https://tenant.ec-auth.io', $validator->normalize('https://tenant.ec-auth.io:443'));
+    }
+
+    public function testExplicitDefaultPortInAllowListIsEquivalentToOmittingIt(): void
+    {
+        $validator = new BaseUrlValidator('ecauth.example.com:443');
+
+        self::assertSame('https://ecauth.example.com', $validator->normalize('https://ecauth.example.com'));
+        self::assertSame('https://ecauth.example.com', $validator->normalize('https://ecauth.example.com:443'));
+        self::assertNull($validator->normalize('https://ecauth.example.com:8443'));
+    }
+
     public function testMultipleEntriesAreSupported(): void
     {
-        $validator = new BaseUrlValidator('.ec-auth.io, .azurewebsites.net, localhost:8081');
+        // 共有ホスティングのサフィックス（.azurewebsites.net 等）は例に使わない。
+        // 推奨設定と誤読されうるため（クラス docblock 参照）。
+        $validator = new BaseUrlValidator('.ec-auth.io, ecauth-staging.example.net, localhost:8081');
 
         self::assertNotNull($validator->normalize('https://tenant.ec-auth.io'));
-        self::assertNotNull($validator->normalize('https://ecauth-dev.azurewebsites.net'));
+        self::assertNotNull($validator->normalize('https://ecauth-staging.example.net'));
         self::assertNotNull($validator->normalize('https://localhost:8081'));
         self::assertNull($validator->normalize('https://evil.example.com'));
     }

--- a/Tests/Unit/BaseUrlValidatorTest.php
+++ b/Tests/Unit/BaseUrlValidatorTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Plugin\EcAuthLogin43\Service\BaseUrlValidator;
+
+/**
+ * EcAuthDocs #101: Base URL はトークン交換先かつ JWKS 取得先になるため、
+ * 許可されないホストを 1 つでも通すと id_token の検証ごと攻撃者に握られる。
+ */
+class BaseUrlValidatorTest extends TestCase
+{
+    public function testSubdomainSuffixIsAllowed(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        self::assertSame('https://tenant.ec-auth.io', $validator->normalize('https://tenant.ec-auth.io'));
+        self::assertSame('https://tenant.ec-auth.io', $validator->normalize('https://tenant.ec-auth.io/'));
+    }
+
+    public function testApexIsNotMatchedBySuffixEntry(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        self::assertNull($validator->normalize('https://ec-auth.io'));
+    }
+
+    public function testSuffixEntryDoesNotMatchLookalikeDomain(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        // "evil-ec-auth.io" のような部分一致で通ってはいけない
+        self::assertNull($validator->normalize('https://tenant.evil-ec-auth.io'));
+        self::assertNull($validator->normalize('https://ec-auth.io.evil.example'));
+    }
+
+    public function testExactHostEntry(): void
+    {
+        $validator = new BaseUrlValidator('ecauth.example.com');
+
+        self::assertSame('https://ecauth.example.com', $validator->normalize('https://ecauth.example.com'));
+        self::assertNull($validator->normalize('https://sub.ecauth.example.com'));
+    }
+
+    public function testHttpIsRejectedUnlessSchemeIsExplicit(): void
+    {
+        $httpsOnly = new BaseUrlValidator('localhost');
+        self::assertNull($httpsOnly->normalize('http://localhost'));
+
+        $withHttp = new BaseUrlValidator('http://localhost:8080');
+        self::assertSame('http://localhost:8080', $withHttp->normalize('http://localhost:8080'));
+    }
+
+    public function testPortMustMatchWhenSpecified(): void
+    {
+        $validator = new BaseUrlValidator('localhost:8081');
+
+        self::assertSame('https://localhost:8081', $validator->normalize('https://localhost:8081'));
+        self::assertNull($validator->normalize('https://localhost:9999'));
+        self::assertNull($validator->normalize('https://localhost'));
+    }
+
+    public function testMultipleEntriesAreSupported(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io, .azurewebsites.net, localhost:8081');
+
+        self::assertNotNull($validator->normalize('https://tenant.ec-auth.io'));
+        self::assertNotNull($validator->normalize('https://ecauth-dev.azurewebsites.net'));
+        self::assertNotNull($validator->normalize('https://localhost:8081'));
+        self::assertNull($validator->normalize('https://evil.example.com'));
+    }
+
+    public function testEmptyAllowListRejectsEverything(): void
+    {
+        $validator = new BaseUrlValidator('');
+
+        self::assertNull($validator->normalize('https://tenant.ec-auth.io'));
+    }
+
+    public function testUrlsWithCredentialsOrPathAreRejected(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        self::assertNull($validator->normalize('https://evil@tenant.ec-auth.io'));
+        self::assertNull($validator->normalize('https://tenant.ec-auth.io/path'));
+        self::assertNull($validator->normalize('https://tenant.ec-auth.io?a=1'));
+        self::assertNull($validator->normalize('https://tenant.ec-auth.io#f'));
+    }
+
+    public function testMalformedInputIsRejected(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        self::assertNull($validator->normalize(null));
+        self::assertNull($validator->normalize(''));
+        self::assertNull($validator->normalize('   '));
+        self::assertNull($validator->normalize('tenant.ec-auth.io'));
+        self::assertNull($validator->normalize('javascript:alert(1)'));
+    }
+
+    public function testHostComparisonIsCaseInsensitive(): void
+    {
+        $validator = new BaseUrlValidator('.EC-AUTH.IO');
+
+        self::assertSame('https://tenant.ec-auth.io', $validator->normalize('HTTPS://Tenant.Ec-Auth.IO'));
+    }
+
+    public function testIsAllowedMirrorsNormalize(): void
+    {
+        $validator = new BaseUrlValidator('.ec-auth.io');
+
+        self::assertTrue($validator->isAllowed('https://tenant.ec-auth.io'));
+        self::assertFalse($validator->isAllowed('https://evil.example.com'));
+    }
+}

--- a/Tests/Unit/CachedJwksProviderTest.php
+++ b/Tests/Unit/CachedJwksProviderTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit;
+
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\TestCase;
+use Plugin\EcAuthLogin43\Service\CachedJwksProvider;
+use Plugin\EcAuthLogin43\Tests\Unit\Support\FakeClientException;
+use Plugin\EcAuthLogin43\Tests\Unit\Support\FakeHttpClient;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class CachedJwksProviderTest extends TestCase
+{
+    private const BASE_URL = 'https://tenant.ec-auth.io';
+
+    public function testFetchesAndCachesKeys(): void
+    {
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+        ]);
+        $cache = new ArrayAdapter();
+        $provider = $this->createProvider($client, $cache);
+
+        $first = $provider->getJwks(self::BASE_URL);
+        $second = $provider->getJwks(self::BASE_URL);
+
+        self::assertIsArray($first);
+        self::assertSame('kid-1', $first[0]['kid']);
+        // 2 回目はキャッシュから返るため HTTP リクエストは 1 回だけ
+        self::assertCount(1, $client->requests);
+        self::assertSame($first, $second);
+        self::assertCount(1, $cache->getValues());
+    }
+
+    public function testRequestsTheJwksEndpointOfTheGivenBaseUrl(): void
+    {
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+        ]);
+        $this->createProvider($client, new ArrayAdapter())->getJwks(self::BASE_URL.'/');
+
+        self::assertSame(
+            self::BASE_URL.'/.well-known/jwks.json',
+            (string) $client->requests[0]->getUri(),
+        );
+    }
+
+    public function testForceRefreshBypassesCache(): void
+    {
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+            ['status' => 200, 'body' => $this->jwksBody('kid-2')],
+        ]);
+        $provider = $this->createProvider($client, new ArrayAdapter());
+
+        $provider->getJwks(self::BASE_URL);
+        $refreshed = $provider->getJwks(self::BASE_URL, true);
+
+        self::assertIsArray($refreshed);
+        self::assertSame('kid-2', $refreshed[0]['kid']);
+        self::assertCount(2, $client->requests);
+    }
+
+    public function testCacheKeyIsDerivedFromBaseUrl(): void
+    {
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-a')],
+            ['status' => 200, 'body' => $this->jwksBody('kid-b')],
+        ]);
+        $provider = $this->createProvider($client, new ArrayAdapter());
+
+        $a = $provider->getJwks('https://tenant-a.ec-auth.io');
+        $b = $provider->getJwks('https://tenant-b.ec-auth.io');
+
+        // テナントごとに鍵が異なるため、キャッシュが混ざってはいけない
+        self::assertSame('kid-a', $a[0]['kid']);
+        self::assertSame('kid-b', $b[0]['kid']);
+    }
+
+    public function testHttpErrorReturnsNull(): void
+    {
+        $client = new FakeHttpClient([['status' => 500, 'body' => '']]);
+
+        self::assertNull($this->createProvider($client, new ArrayAdapter())->getJwks(self::BASE_URL));
+    }
+
+    public function testTransportErrorReturnsNull(): void
+    {
+        $client = new FakeHttpClient([new FakeClientException('connection refused')]);
+
+        self::assertNull($this->createProvider($client, new ArrayAdapter())->getJwks(self::BASE_URL));
+    }
+
+    public function testMalformedResponseReturnsNull(): void
+    {
+        $cache = new ArrayAdapter();
+
+        self::assertNull(
+            $this->createProvider(new FakeHttpClient([['status' => 200, 'body' => 'not json']]), $cache)
+                ->getJwks(self::BASE_URL),
+        );
+        self::assertNull(
+            $this->createProvider(new FakeHttpClient([['status' => 200, 'body' => '{"keys":[]}']]), $cache)
+                ->getJwks(self::BASE_URL),
+        );
+        self::assertNull(
+            $this->createProvider(new FakeHttpClient([['status' => 200, 'body' => '{"foo":1}']]), $cache)
+                ->getJwks(self::BASE_URL),
+        );
+        // 取得失敗をキャッシュしてはいけない。
+        // ArrayAdapter はミス時にもキーを null で保持するため、実値だけを見る。
+        self::assertSame([], array_filter($cache->getValues(), static function ($value) {
+            return $value !== null;
+        }));
+    }
+
+    public function testEmptyBaseUrlReturnsNullWithoutRequest(): void
+    {
+        $client = new FakeHttpClient([]);
+
+        self::assertNull($this->createProvider($client, new ArrayAdapter())->getJwks(''));
+        self::assertCount(0, $client->requests);
+    }
+
+    private function createProvider(FakeHttpClient $client, ArrayAdapter $cache): CachedJwksProvider
+    {
+        return new CachedJwksProvider($client, new Psr17Factory(), $cache, new NullLogger());
+    }
+
+    private function jwksBody(string $kid): string
+    {
+        return (string) json_encode([
+            'keys' => [
+                [
+                    'kty' => 'RSA',
+                    'use' => 'sig',
+                    'alg' => 'RS256',
+                    'kid' => $kid,
+                    'n' => 'dGVzdC1tb2R1bHVz',
+                    'e' => 'AQAB',
+                ],
+            ],
+        ]);
+    }
+}

--- a/Tests/Unit/CachedJwksProviderTest.php
+++ b/Tests/Unit/CachedJwksProviderTest.php
@@ -5,6 +5,7 @@ namespace Plugin\EcAuthLogin43\Tests\Unit;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Plugin\EcAuthLogin43\Service\CachedJwksProvider;
+use Plugin\EcAuthLogin43\Tests\Unit\Support\FailingCachePool;
 use Plugin\EcAuthLogin43\Tests\Unit\Support\FakeClientException;
 use Plugin\EcAuthLogin43\Tests\Unit\Support\FakeHttpClient;
 use Psr\Log\NullLogger;
@@ -154,6 +155,45 @@ class CachedJwksProviderTest extends TestCase
 
         self::assertNull($this->createProvider($client, new ArrayAdapter())->getJwks(''));
         self::assertCount(0, $client->requests);
+    }
+
+    public function testCacheBackendFailureDoesNotBreakVerification(): void
+    {
+        // JWKS 自体は取得できているのに、キャッシュ障害で認証が落ちてはいけない
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+        ]);
+        $provider = new CachedJwksProvider(
+            $client,
+            new Psr17Factory(),
+            new FailingCachePool(true),
+            new NullLogger(),
+        );
+
+        $keys = $provider->getJwks(self::BASE_URL);
+
+        self::assertIsArray($keys);
+        self::assertSame('kid-1', $keys[0]['kid']);
+
+        // 強制再取得の経路（クールダウンマーカーの保存）でも例外を漏らさない
+        self::assertIsArray($provider->getJwks(self::BASE_URL, true));
+    }
+
+    public function testUnavailableCacheBackendStillReturnsKeys(): void
+    {
+        // getItem() 自体が投げるケース（Redis 接続断など）
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+        ]);
+        $provider = new CachedJwksProvider(
+            $client,
+            new Psr17Factory(),
+            new FailingCachePool(false, true),
+            new NullLogger(),
+        );
+
+        self::assertIsArray($provider->getJwks(self::BASE_URL));
     }
 
     private function createProvider(FakeHttpClient $client, ArrayAdapter $cache): CachedJwksProvider

--- a/Tests/Unit/CachedJwksProviderTest.php
+++ b/Tests/Unit/CachedJwksProviderTest.php
@@ -62,6 +62,39 @@ class CachedJwksProviderTest extends TestCase
         self::assertCount(2, $client->requests);
     }
 
+    public function testRepeatedForceRefreshIsRateLimited(): void
+    {
+        // kid を変え続けるトークンで JWKS エンドポイントへのリクエストを
+        // 増幅できないこと（キャッシュがある限りクールダウン中は取りに行かない）
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+            ['status' => 200, 'body' => $this->jwksBody('kid-2')],
+        ]);
+        $provider = $this->createProvider($client, new ArrayAdapter());
+
+        $provider->getJwks(self::BASE_URL);
+        $provider->getJwks(self::BASE_URL, true);
+        for ($i = 0; $i < 10; ++$i) {
+            $throttled = $provider->getJwks(self::BASE_URL, true);
+            self::assertIsArray($throttled);
+        }
+
+        // 初回取得 + 1 回目の強制再取得のみ。以降はクールダウンで抑制される
+        self::assertCount(2, $client->requests);
+    }
+
+    public function testForceRefreshIsAllowedWhenNothingIsCached(): void
+    {
+        // キャッシュが無ければ返せるものが無いので、クールダウンより取得を優先する
+        $client = new FakeHttpClient([
+            ['status' => 200, 'body' => $this->jwksBody('kid-1')],
+        ]);
+        $provider = $this->createProvider($client, new ArrayAdapter());
+
+        self::assertIsArray($provider->getJwks(self::BASE_URL, true));
+        self::assertCount(1, $client->requests);
+    }
+
     public function testCacheKeyIsDerivedFromBaseUrl(): void
     {
         $client = new FakeHttpClient([

--- a/Tests/Unit/IdTokenVerifierTest.php
+++ b/Tests/Unit/IdTokenVerifierTest.php
@@ -120,11 +120,56 @@ class IdTokenVerifierTest extends TestCase
         self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
     }
 
-    public function testAudienceAsArrayIsAccepted(): void
+    public function testAudienceAsArrayIsAcceptedWhenAzpIdentifiesThisClient(): void
     {
-        $token = self::$key->sign($this->claims(['aud' => ['another-client-id', self::AUDIENCE]]));
+        $token = self::$key->sign($this->claims([
+            'aud' => ['another-client-id', self::AUDIENCE],
+            'azp' => self::AUDIENCE,
+        ]));
 
         self::assertIsArray($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testMultipleAudiencesWithoutAzpIsRejected(): void
+    {
+        // OIDC Core 3.1.3.7 (4): aud が複数なら azp の存在確認が必要
+        $token = self::$key->sign($this->claims(['aud' => ['another-client-id', self::AUDIENCE]]));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testAzpForAnotherClientIsRejected(): void
+    {
+        // 別クライアント向けに発行された（署名は正当な）トークンの使い回しを防ぐ
+        $token = self::$key->sign($this->claims([
+            'aud' => ['another-client-id', self::AUDIENCE],
+            'azp' => 'another-client-id',
+        ]));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testAzpIsCheckedEvenForSingleAudience(): void
+    {
+        // OIDC Core 3.1.3.7 (5): azp があれば aud が単一でも一致を要求する
+        $token = self::$key->sign($this->claims(['azp' => 'another-client-id']));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testMatchingAzpWithSingleAudienceIsAccepted(): void
+    {
+        $token = self::$key->sign($this->claims(['azp' => self::AUDIENCE]));
+
+        self::assertIsArray($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testIssuerDifferingOnlyByTrailingSlashIsRejected(): void
+    {
+        // OIDC Core 3.1.3.7 (2): iss は完全一致で比較する
+        $token = self::$key->sign($this->claims(['iss' => self::ISSUER.'/']));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
     }
 
     public function testMissingExpIsRejected(): void

--- a/Tests/Unit/IdTokenVerifierTest.php
+++ b/Tests/Unit/IdTokenVerifierTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Plugin\EcAuthLogin43\Service\IdTokenVerifier;
+use Plugin\EcAuthLogin43\Tests\Unit\Support\FakeJwksProvider;
+use Plugin\EcAuthLogin43\Tests\Unit\Support\RsaKeyFixture;
+use Psr\Log\NullLogger;
+
+/**
+ * EcAuthDocs #101 の回帰テスト。
+ *
+ * id_token は管理者セッション確立の起点になるため、署名・iss・aud・exp の
+ * いずれかが欠けたトークンを 1 つでも通すと管理者なりすましが成立する。
+ * ここでは「通ってはいけないトークン」を網羅的に落とすことを主眼に置く。
+ */
+class IdTokenVerifierTest extends TestCase
+{
+    private const ISSUER = 'https://tenant.example.com';
+    private const AUDIENCE = 'ec-test-client-id';
+
+    /**
+     * @var RsaKeyFixture
+     */
+    private static $key;
+
+    /**
+     * @var RsaKeyFixture 別テナント（攻撃者）の鍵
+     */
+    private static $otherKey;
+
+    public static function setUpBeforeClass(): void
+    {
+        // 鍵生成は遅いのでクラス単位で 1 度だけ行う
+        self::$key = new RsaKeyFixture('kid-primary');
+        self::$otherKey = new RsaKeyFixture('kid-attacker');
+    }
+
+    public function testValidTokenIsAccepted(): void
+    {
+        $token = self::$key->sign($this->claims());
+
+        $payload = $this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE);
+
+        self::assertIsArray($payload);
+        self::assertSame('b2b-subject-uuid', $payload['sub']);
+    }
+
+    public function testTrailingSlashInConfiguredIssuerIsTolerated(): void
+    {
+        $token = self::$key->sign($this->claims());
+
+        $payload = $this->createVerifier()->verify($token, self::ISSUER.'/', self::AUDIENCE);
+
+        self::assertIsArray($payload);
+    }
+
+    public function testTamperedSignatureIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims());
+        // 署名の末尾 1 文字を書き換える
+        $tampered = substr($token, 0, -1).(substr($token, -1) === 'A' ? 'B' : 'A');
+
+        self::assertNull($this->createVerifier()->verify($tampered, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testTokenSignedByAnotherKeyIsRejected(): void
+    {
+        // 攻撃者が自分の鍵で署名し、kid だけ正規のものに偽装したケース
+        $token = self::$otherKey->sign($this->claims(), ['kid' => 'kid-primary']);
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testAlgNoneIsRejected(): void
+    {
+        $token = self::$key->forge($this->claims(), ['alg' => 'none'], '');
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testHmacAlgorithmIsRejected(): void
+    {
+        // 公開鍵を HMAC の鍵として使う alg confusion の典型パターン
+        $jwk = self::$key->jwk();
+        $payloadSegment = RsaKeyFixture::base64UrlEncode((string) json_encode($this->claims()));
+        $headerSegment = RsaKeyFixture::base64UrlEncode((string) json_encode([
+            'alg' => 'HS256',
+            'typ' => 'JWT',
+            'kid' => 'kid-primary',
+        ]));
+        $signature = hash_hmac('sha256', $headerSegment.'.'.$payloadSegment, $jwk['n'], true);
+        $token = $headerSegment.'.'.$payloadSegment.'.'.RsaKeyFixture::base64UrlEncode($signature);
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testIssuerMismatchIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims(['iss' => 'https://evil.example.com']));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testAudienceMismatchIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims(['aud' => 'another-client-id']));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testAudienceAsArrayIsAccepted(): void
+    {
+        $token = self::$key->sign($this->claims(['aud' => ['another-client-id', self::AUDIENCE]]));
+
+        self::assertIsArray($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testMissingExpIsRejected(): void
+    {
+        $claims = $this->claims();
+        unset($claims['exp']);
+        $token = self::$key->sign($claims);
+
+        // 修正前は exp が無いトークンが通っていた（EcAuthDocs #101）
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testExpiredTokenIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims(['exp' => 1_700_000_000 - 3600]));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testTokenWithFutureNbfIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims(['nbf' => 1_700_000_000 + 3600]));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testTokenIssuedInTheFutureIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims(['iat' => 1_700_000_000 + 3600]));
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testMissingSubIsRejected(): void
+    {
+        $claims = $this->claims();
+        unset($claims['sub']);
+        $token = self::$key->sign($claims);
+
+        self::assertNull($this->createVerifier()->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testMalformedTokenIsRejected(): void
+    {
+        $verifier = $this->createVerifier();
+
+        self::assertNull($verifier->verify('not-a-jwt', self::ISSUER, self::AUDIENCE));
+        self::assertNull($verifier->verify('a.b', self::ISSUER, self::AUDIENCE));
+        self::assertNull($verifier->verify('', self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testVerificationIsSkippedWhenIssuerOrAudienceIsNotConfigured(): void
+    {
+        $token = self::$key->sign($this->claims());
+        $verifier = $this->createVerifier();
+
+        self::assertNull($verifier->verify($token, '', self::AUDIENCE));
+        self::assertNull($verifier->verify($token, self::ISSUER, ''));
+    }
+
+    public function testUnavailableJwksIsRejected(): void
+    {
+        $token = self::$key->sign($this->claims());
+        $verifier = new TestableIdTokenVerifier(new FakeJwksProvider(null), new NullLogger());
+
+        self::assertNull($verifier->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testRotatedKeyIsPickedUpByForcedRefresh(): void
+    {
+        $rotatedKey = new RsaKeyFixture('kid-rotated');
+        $token = $rotatedKey->sign($this->claims());
+
+        // キャッシュ済み JWKS には新しい kid が無く、再取得で見つかる状況
+        $provider = new FakeJwksProvider([self::$key->jwk()], [$rotatedKey->jwk()]);
+        $verifier = new TestableIdTokenVerifier($provider, new NullLogger());
+
+        self::assertIsArray($verifier->verify($token, self::ISSUER, self::AUDIENCE));
+        self::assertSame([false, true], $provider->calls);
+    }
+
+    public function testSignatureFailureDoesNotTriggerAnotherFetch(): void
+    {
+        // 鍵は見つかるが署名が不正なケースでは再取得しない（無駄な外部リクエストを避ける）
+        $token = self::$otherKey->sign($this->claims(), ['kid' => 'kid-primary']);
+        $provider = new FakeJwksProvider([self::$key->jwk()]);
+        $verifier = new TestableIdTokenVerifier($provider, new NullLogger());
+
+        self::assertNull($verifier->verify($token, self::ISSUER, self::AUDIENCE));
+        self::assertSame([false], $provider->calls);
+    }
+
+    public function testKeyWithoutKidIsUsedOnlyWhenUnambiguous(): void
+    {
+        $token = self::$key->signWithExactHeader($this->claims(), ['alg' => 'RS256', 'typ' => 'JWT']);
+
+        $jwk = self::$key->jwk();
+        unset($jwk['kid']);
+        $verifier = new TestableIdTokenVerifier(new FakeJwksProvider([$jwk]), new NullLogger());
+        self::assertIsArray($verifier->verify($token, self::ISSUER, self::AUDIENCE));
+
+        // 候補が複数ある場合は kid 無しでは鍵を特定できないので拒否する
+        $otherJwk = self::$otherKey->jwk();
+        unset($otherJwk['kid']);
+        $ambiguous = new TestableIdTokenVerifier(new FakeJwksProvider([$jwk, $otherJwk]), new NullLogger());
+        self::assertNull($ambiguous->verify($token, self::ISSUER, self::AUDIENCE));
+    }
+
+    /**
+     * @param array<string, mixed> $override
+     *
+     * @return array<string, mixed>
+     */
+    private function claims(array $override = []): array
+    {
+        return array_merge([
+            'sub' => 'b2b-subject-uuid',
+            'iss' => self::ISSUER,
+            'aud' => self::AUDIENCE,
+            'iat' => 1_700_000_000 - 60,
+            'nbf' => 1_700_000_000 - 60,
+            'exp' => 1_700_000_000 + 3600,
+            'jti' => 'token-id',
+        ], $override);
+    }
+
+    private function createVerifier(): TestableIdTokenVerifier
+    {
+        return new TestableIdTokenVerifier(
+            new FakeJwksProvider([self::$key->jwk()]),
+            new NullLogger(),
+        );
+    }
+}
+
+/**
+ * 時刻を固定して検証するためのサブクラス。
+ */
+class TestableIdTokenVerifier extends IdTokenVerifier
+{
+    protected function now(): int
+    {
+        return 1_700_000_000;
+    }
+}

--- a/Tests/Unit/IdTokenVerifierTest.php
+++ b/Tests/Unit/IdTokenVerifierTest.php
@@ -58,9 +58,19 @@ class IdTokenVerifierTest extends TestCase
 
     public function testTamperedSignatureIsRejected(): void
     {
+        $tampered = RsaKeyFixture::tamperSignature(self::$key->sign($this->claims()));
+
+        self::assertNull($this->createVerifier()->verify($tampered, self::ISSUER, self::AUDIENCE));
+    }
+
+    public function testTamperedPayloadIsRejected(): void
+    {
+        // 正規のトークンの sub だけを別の管理者のものに差し替える（署名は元のまま）
         $token = self::$key->sign($this->claims());
-        // 署名の末尾 1 文字を書き換える
-        $tampered = substr($token, 0, -1).(substr($token, -1) === 'A' ? 'B' : 'A');
+        $parts = explode('.', $token);
+        $payload = json_decode(RsaKeyFixture::base64UrlDecode($parts[1]), true);
+        $payload['sub'] = 'another-admin-subject';
+        $tampered = $parts[0].'.'.RsaKeyFixture::base64UrlEncode((string) json_encode($payload)).'.'.$parts[2];
 
         self::assertNull($this->createVerifier()->verify($tampered, self::ISSUER, self::AUDIENCE));
     }

--- a/Tests/Unit/Support/FailingCachePool.php
+++ b/Tests/Unit/Support/FailingCachePool.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit\Support;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * キャッシュバックエンドの障害を再現するテストダブル。
+ *
+ * PSR-6 は save() / getItem() が CacheException を投げることを許容しており、
+ * Redis 等のアダプタは接続断で実際に投げる。JWKS 自体は取得できているのに
+ * キャッシュ障害で認証が 500 になっては本末転倒なので、その挙動を検証する。
+ */
+class FailingCachePool implements CacheItemPoolInterface
+{
+    /**
+     * @var ArrayAdapter
+     */
+    private $inner;
+
+    /**
+     * @var bool save() で例外を投げる
+     */
+    private $throwOnSave;
+
+    /**
+     * @var bool getItem() で例外を投げる
+     */
+    private $throwOnGetItem;
+
+    public function __construct(bool $throwOnSave = false, bool $throwOnGetItem = false)
+    {
+        $this->inner = new ArrayAdapter();
+        $this->throwOnSave = $throwOnSave;
+        $this->throwOnGetItem = $throwOnGetItem;
+    }
+
+    public function getItem($key): CacheItemInterface
+    {
+        if ($this->throwOnGetItem) {
+            throw new FakeCacheException('cache backend is unavailable');
+        }
+
+        return $this->inner->getItem($key);
+    }
+
+    public function getItems(array $keys = []): iterable
+    {
+        return $this->inner->getItems($keys);
+    }
+
+    public function hasItem($key): bool
+    {
+        return $this->inner->hasItem($key);
+    }
+
+    public function clear(): bool
+    {
+        return $this->inner->clear();
+    }
+
+    public function deleteItem($key): bool
+    {
+        return $this->inner->deleteItem($key);
+    }
+
+    public function deleteItems(array $keys): bool
+    {
+        return $this->inner->deleteItems($keys);
+    }
+
+    public function save(CacheItemInterface $item): bool
+    {
+        if ($this->throwOnSave) {
+            throw new FakeCacheException('cache backend is unavailable');
+        }
+
+        return $this->inner->save($item);
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        return $this->save($item);
+    }
+
+    public function commit(): bool
+    {
+        return $this->inner->commit();
+    }
+}

--- a/Tests/Unit/Support/FakeCacheException.php
+++ b/Tests/Unit/Support/FakeCacheException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit\Support;
+
+use Psr\Cache\CacheException;
+
+/**
+ * キャッシュバックエンド障害を再現するための PSR-6 例外。
+ */
+class FakeCacheException extends \RuntimeException implements CacheException
+{
+}

--- a/Tests/Unit/Support/FakeClientException.php
+++ b/Tests/Unit/Support/FakeClientException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit\Support;
+
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * ネットワーク障害を再現するための PSR-18 例外。
+ */
+class FakeClientException extends \RuntimeException implements ClientExceptionInterface
+{
+}

--- a/Tests/Unit/Support/FakeHttpClient.php
+++ b/Tests/Unit/Support/FakeHttpClient.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit\Support;
+
+use Nyholm\Psr7\Response;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * 応答をキューで返す PSR-18 クライアントのテストダブル。
+ */
+class FakeHttpClient implements ClientInterface
+{
+    /**
+     * @var array<int, array{status: int, body: string}|\Throwable>
+     */
+    private $queue;
+
+    /**
+     * 送信されたリクエストの記録。
+     *
+     * @var array<int, RequestInterface>
+     */
+    public $requests = [];
+
+    /**
+     * @param array<int, array{status: int, body: string}|\Throwable> $queue
+     */
+    public function __construct(array $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->requests[] = $request;
+
+        $next = array_shift($this->queue);
+        if ($next === null) {
+            throw new \RuntimeException('FakeHttpClient received an unexpected request');
+        }
+        if ($next instanceof \Throwable) {
+            /* @var ClientExceptionInterface&\Throwable $next */
+            throw $next;
+        }
+
+        return new Response($next['status'], ['Content-Type' => 'application/json'], $next['body']);
+    }
+}

--- a/Tests/Unit/Support/FakeJwksProvider.php
+++ b/Tests/Unit/Support/FakeJwksProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit\Support;
+
+use Plugin\EcAuthLogin43\Service\JwksProviderInterface;
+
+/**
+ * JWKS 取得を差し替えるテストダブル。
+ *
+ * $refreshedKeys を設定すると、forceRefresh = true のときだけ別の鍵セットを返す。
+ * 鍵ローテーション時の再取得挙動を検証するために使う。
+ */
+class FakeJwksProvider implements JwksProviderInterface
+{
+    /**
+     * @var array<int, array<string, mixed>>|null
+     */
+    public $keys;
+
+    /**
+     * @var array<int, array<string, mixed>>|null
+     */
+    public $refreshedKeys;
+
+    /**
+     * getJwks() が forceRefresh に何を渡されたかの記録。
+     *
+     * @var array<int, bool>
+     */
+    public $calls = [];
+
+    /**
+     * @param array<int, array<string, mixed>>|null $keys
+     * @param array<int, array<string, mixed>>|null $refreshedKeys
+     */
+    public function __construct(?array $keys, ?array $refreshedKeys = null)
+    {
+        $this->keys = $keys;
+        $this->refreshedKeys = $refreshedKeys;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getJwks(string $baseUrl, bool $forceRefresh = false): ?array
+    {
+        $this->calls[] = $forceRefresh;
+
+        if ($forceRefresh && $this->refreshedKeys !== null) {
+            return $this->refreshedKeys;
+        }
+
+        return $this->keys;
+    }
+}

--- a/Tests/Unit/Support/RsaKeyFixture.php
+++ b/Tests/Unit/Support/RsaKeyFixture.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit\Support;
+
+/**
+ * テスト用の RSA 鍵ペアを生成し、JWK と署名済み JWT を組み立てるヘルパー。
+ *
+ * 鍵生成は遅いのでテストクラスごとに 1 回だけ生成して使い回すこと。
+ */
+class RsaKeyFixture
+{
+    /**
+     * @var resource|\OpenSSLAsymmetricKey
+     */
+    private $privateKey;
+
+    /**
+     * @var string
+     */
+    private $modulus;
+
+    /**
+     * @var string
+     */
+    private $exponent;
+
+    /**
+     * @var string
+     */
+    private $kid;
+
+    public function __construct(string $kid = 'test-kid')
+    {
+        $key = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        if ($key === false) {
+            throw new \RuntimeException('Failed to generate an RSA key pair for tests');
+        }
+
+        $details = openssl_pkey_get_details($key);
+        if ($details === false || !isset($details['rsa']['n'], $details['rsa']['e'])) {
+            throw new \RuntimeException('Failed to read RSA key details for tests');
+        }
+
+        $this->privateKey = $key;
+        $this->modulus = $details['rsa']['n'];
+        $this->exponent = $details['rsa']['e'];
+        $this->kid = $kid;
+    }
+
+    public function kid(): string
+    {
+        return $this->kid;
+    }
+
+    /**
+     * EcAuth の JwksController が返すのと同じ形の JWK を組み立てる。
+     *
+     * @return array<string, string>
+     */
+    public function jwk(): array
+    {
+        return [
+            'kty' => 'RSA',
+            'use' => 'sig',
+            'alg' => 'RS256',
+            'kid' => $this->kid,
+            'n' => self::base64UrlEncode($this->modulus),
+            'e' => self::base64UrlEncode($this->exponent),
+        ];
+    }
+
+    /**
+     * RS256 で署名した JWT を組み立てる。
+     *
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $headerOverride ヘッダを差し替える（alg 差し替えテスト用）
+     */
+    public function sign(array $payload, array $headerOverride = []): string
+    {
+        return $this->signWithExactHeader($payload, array_merge([
+            'alg' => 'RS256',
+            'typ' => 'JWT',
+            'kid' => $this->kid,
+        ], $headerOverride));
+    }
+
+    /**
+     * ヘッダをそのまま使って RS256 署名する（kid を持たないトークンの生成用）。
+     *
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $header
+     */
+    public function signWithExactHeader(array $payload, array $header): string
+    {
+        $signingInput = self::base64UrlEncode((string) json_encode($header))
+            .'.'.self::base64UrlEncode((string) json_encode($payload));
+
+        $signature = '';
+        openssl_sign($signingInput, $signature, $this->privateKey, OPENSSL_ALGO_SHA256);
+
+        return $signingInput.'.'.self::base64UrlEncode($signature);
+    }
+
+    /**
+     * 署名を持たない（あるいは任意の文字列を署名として置いた）JWT を組み立てる。
+     *
+     * @param array<string, mixed> $payload
+     * @param array<string, mixed> $headerOverride
+     */
+    public function forge(array $payload, array $headerOverride, string $signature): string
+    {
+        $header = array_merge([
+            'typ' => 'JWT',
+            'kid' => $this->kid,
+        ], $headerOverride);
+
+        return self::base64UrlEncode((string) json_encode($header))
+            .'.'.self::base64UrlEncode((string) json_encode($payload))
+            .'.'.self::base64UrlEncode($signature);
+    }
+
+    public static function base64UrlEncode(string $raw): string
+    {
+        return rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
+    }
+}

--- a/Tests/Unit/Support/RsaKeyFixture.php
+++ b/Tests/Unit/Support/RsaKeyFixture.php
@@ -126,4 +126,31 @@ class RsaKeyFixture
     {
         return rtrim(strtr(base64_encode($raw), '+/', '-_'), '=');
     }
+
+    public static function base64UrlDecode(string $input): string
+    {
+        $remainder = strlen($input) % 4;
+        if ($remainder !== 0) {
+            $input .= str_repeat('=', 4 - $remainder);
+        }
+
+        return (string) base64_decode(strtr($input, '-_', '+/'), true);
+    }
+
+    /**
+     * 署名バイト列の先頭 1 バイトを反転させた JWT を返す。
+     *
+     * base64url 文字列の末尾 1 文字を書き換える方法だと、末尾文字が持つ
+     * パディングビットしか変わらずデコード結果が同一になる場合があり、
+     * 署名が有効なままになってしまう（PHP バージョンや鍵によって再現が変わる）。
+     * バイト列側を確実に変える。
+     */
+    public static function tamperSignature(string $token): string
+    {
+        $parts = explode('.', $token);
+        $signature = self::base64UrlDecode($parts[2]);
+        $signature[0] = chr(ord($signature[0]) ^ 0xff);
+
+        return $parts[0].'.'.$parts[1].'.'.self::base64UrlEncode($signature);
+    }
 }

--- a/Tests/Unit/Support/RsaKeyFixture.php
+++ b/Tests/Unit/Support/RsaKeyFixture.php
@@ -99,7 +99,11 @@ class RsaKeyFixture
             .'.'.self::base64UrlEncode((string) json_encode($payload));
 
         $signature = '';
-        openssl_sign($signingInput, $signature, $this->privateKey, OPENSSL_ALGO_SHA256);
+        // 署名生成に失敗すると空署名のトークンができ、「拒否されること」を確認する
+        // 多数のテストが理由を取り違えたまま成功してしまう（偽陰性）。
+        if (!openssl_sign($signingInput, $signature, $this->privateKey, OPENSSL_ALGO_SHA256)) {
+            throw new \RuntimeException('Failed to sign a test JWT');
+        }
 
         return $signingInput.'.'.self::base64UrlEncode($signature);
     }

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -12,6 +12,10 @@ const ADVANCED_PANEL = '#ecauth-advanced-settings';
 const SIGNUP_URL = process.env.ECAUTH_SIGNUP_URL || 'https://ec-auth.io/signup/';
 const MYPAGE_URL = process.env.ECAUTH_MYPAGE_URL || 'https://ec-auth.io/mypage/';
 
+// EcAuth URL は許可リスト（ECAUTH_ALLOWED_HOSTS、既定は .ec-auth.io）を通るホストしか
+// 保存できない（EcAuthDocs #101）。保存できる例として ec-auth.io のサブドメインを使う。
+const ALLOWED_BASE_URL = 'https://e2e-tenant.ec-auth.io';
+
 test.describe('プラグイン設定画面', () => {
   test.beforeEach(async ({ page }) => {
     // 管理画面ログイン
@@ -81,7 +85,7 @@ test.describe('プラグイン設定画面', () => {
     // 高度な設定を展開して URL を入力（resolve をスキップ）
     await page.click(ADVANCED_TOGGLE);
     await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
-    await page.fill('input[name="config[ecauth_base_url]"]', 'https://auth.example.com');
+    await page.fill('input[name="config[ecauth_base_url]"]', ALLOWED_BASE_URL);
 
     await page.click('button[type="submit"]');
 
@@ -93,6 +97,31 @@ test.describe('プラグイン設定画面', () => {
     await expect(page.locator('input[name="config[client_id]"]')).toHaveValue('test-client-id');
     await page.click(ADVANCED_TOGGLE);
     await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
-    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue('https://auth.example.com');
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(ALLOWED_BASE_URL);
+  });
+
+  // EcAuthDocs #101: Base URL はトークン交換先かつ JWKS 取得先になるため、
+  // 許可リスト外のホストは保存段階で弾く。
+  test('#101: 許可されていないホストの EcAuth URL は保存できない', async ({ page }) => {
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+
+    await page.fill('input[name="config[client_id]"]', 'test-client-id');
+    await page.fill('input[name="config[client_secret]"]', 'test-client-secret');
+
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
+    await page.fill('input[name="config[ecauth_base_url]"]', 'https://auth.example.com');
+
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator('.alert-success')).not.toBeVisible();
+    await expect(page.locator('text=許可されていないホスト')).toBeVisible();
+
+    // 拒否された値が保存されていないこと
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).not.toHaveValue(
+      'https://auth.example.com',
+    );
   });
 });

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,27 @@
   },
   "require": {
     "ec-cube/plugin-installer": "^2.0",
+    "psr/cache": "^1.0 || ^2.0 || ^3.0",
     "psr/http-client": "^1.0",
     "psr/http-factory": "^1.0",
-    "psr/http-message": "^1.0 || ^2.0"
+    "psr/http-message": "^1.0 || ^2.0",
+    "psr/log": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^3.64",
+    "nyholm/psr7": "^1.8",
     "phpstan/phpstan": "^1.10",
-    "rector/rector": "^1.0"
+    "phpunit/phpunit": "^9.6",
+    "rector/rector": "^1.0",
+    "symfony/cache": "^5.4 || ^6.4 || ^7.0"
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Plugin\\EcAuthLogin43\\": ""
+    }
+  },
+  "scripts": {
+    "phpunit": "phpunit --configuration phpunit.xml.dist"
   },
   "config": {
     "allow-plugins": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,13 @@ services:
       ECCUBE_AUTHENTICATION_KEY: ${ECCUBE_AUTHENTICATION_KEY:-}
       # package-api から入れるプラグインのバージョン（空なら最新）。非秘密なのでそのまま渡す。
       ECAUTH_PLUGIN_VERSION: ${ECAUTH_PLUGIN_VERSION:-}
-      # EcAuth Base URL として許可するホスト（カンマ区切り）。既定は ec-auth.io の
-      # サブドメインのみのため、開発・ステージングの Azure ホストを明示的に足す。
-      # 未設定だと dev / staging の EcAuth を設定できず、パスキーログインが通らない。
-      ECAUTH_ALLOWED_HOSTS: ${ECAUTH_ALLOWED_HOSTS:-.ec-auth.io,.azurewebsites.net}
+      # EcAuth Base URL として許可するホスト（カンマ区切り）。
+      # dev / staging の EcAuth は ec-auth.io 配下に無いため、そこへ繋ぐ場合は
+      # ECAUTH_ALLOWED_HOSTS に「完全なホスト名」を足すこと（.env.tpl 参照）。
+      # .azurewebsites.net のようなサフィックス指定にはしないこと。共有ホスティングの
+      # サフィックスを許可すると、そのサービスの全利用者を信頼することになり、
+      # EcAuthDocs #101 の修正の意味が失われる。
+      ECAUTH_ALLOWED_HOSTS: ${ECAUTH_ALLOWED_HOSTS:-.ec-auth.io}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,10 @@ services:
       ECCUBE_AUTHENTICATION_KEY: ${ECCUBE_AUTHENTICATION_KEY:-}
       # package-api から入れるプラグインのバージョン（空なら最新）。非秘密なのでそのまま渡す。
       ECAUTH_PLUGIN_VERSION: ${ECAUTH_PLUGIN_VERSION:-}
+      # EcAuth Base URL として許可するホスト（カンマ区切り）。既定は ec-auth.io の
+      # サブドメインのみのため、開発・ステージングの Azure ホストを明示的に足す。
+      # 未設定だと dev / staging の EcAuth を設定できず、パスキーログインが通らない。
+      ECAUTH_ALLOWED_HOSTS: ${ECAUTH_ALLOWED_HOSTS:-.ec-auth.io,.azurewebsites.net}
     depends_on:
       postgres:
         condition: service_healthy

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         beStrictAboutOutputDuringTests="true">
+    <!--
+      EC-CUBE 本体に依存しない純粋なユニットテストのみを対象にする。
+      EC-CUBE のカーネルを起動するテストは E2E (Playwright) 側で担保する。
+    -->
+    <testsuites>
+        <testsuite name="unit">
+            <directory>Tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
## 背景

EcAuthDocs #101 (Security/High) の 4 系側の対応です。

プラグインは EcAuth から受け取った id_token を **署名検証せずに payload をデコードし、`sub` だけで `dtb_member` を引き当てて管理者セッションを確立** していました。トークン応答を差し込める攻撃者は任意の `sub` で管理者になりすませます。`exp` も「存在する場合のみ」チェックだったため、`exp` を削除したトークンは無期限に通っていました。

さらに Base URL（トークン交換先）が無検証で採用されるため、設定汚染・SSRF・中間者によってその差し込み自体が成立しえます。

## 変更内容

### 1. id_token の検証 (`Service/IdTokenVerifier.php`)

| 検証項目 | 内容 |
|---|---|
| `alg` | `RS256` のみ許可（`none` / HS256 への差し替えを拒否） |
| 署名 | JWKS の公開鍵で RS256 検証（`openssl_verify`） |
| `iss` | 設定済み Base URL と一致 |
| `aud` | 自身の client_id と一致（文字列・配列の両表現に対応） |
| `exp` | **必須**。欠落トークンは拒否 |
| `nbf` / `iat` | 存在する場合、未来でないこと |

いずれか 1 つでも失敗したら `null` を返す fail-closed です。

### 2. JWKS の取得とキャッシュ (`Service/CachedJwksProvider.php`)

`{base_url}/.well-known/jwks.json` を PSR-6 キャッシュ（EC-CUBE 本体の `cache.app`）付きで取得します。TTL は 300 秒。`kid` が見つからないときのみ 1 度だけ強制再取得し、鍵ローテーションに追従します。署名検証の失敗では再取得しません（外部リクエストの無駄打ちを避けるため）。

### 3. Base URL の許可リスト (`Service/BaseUrlValidator.php`)

Base URL はトークン交換先かつ JWKS の取得先なので、ここが攻撃者のホストに向くと「攻撃者の鍵で署名検証が成立」してしまいます。信頼の起点としてホストを許可リストで縛りました。

- 既定は `.ec-auth.io`（サブドメインのみ、apex は含まない）
- 環境変数 `ECAUTH_ALLOWED_HOSTS`（カンマ区切り）で上書き可能
- https 必須。http を許す場合はエントリにスキームを明示する
- 認証情報付き URL・パス/クエリ付き URL は拒否
- **設定画面の保存時**（手入力・client-resolve 応答の両方）と **`EcAuthApiClient` の実行時** の両方で検証

### 4. 外部依存を増やさない実装方針

2 系プラグインは runtime composer を持たずアーカイブ配布のみで、EC-CUBE 4.2/4.3 コアも JWT ライブラリを同梱していません。両系で同一ロジックを持てるよう、JWT ライブラリには依存せず OpenSSL のみを使っています。自前で書いたのは JWK の `n` / `e` から SubjectPublicKeyInfo の DER を組み立てて PEM 化する部分だけで、署名検証そのものは OpenSSL に委譲しています。

### 5. PHPUnit の導入

このリポジトリには従来ユニットテストがなかったため、PHPUnit を導入しました（`phpunit.xml.dist` / `Tests/Unit/`）。EC-CUBE カーネルに依存しない純粋なユニットテストのみを対象にしています。CI は PHP 7.4 / 8.3 のマトリクスで実行します。

## 破壊的変更 ⚠️

**許可リストの導入により、既存の設定が保存・利用できなくなる場合があります。**

- dev / staging の EcAuth は `*.azurewebsites.net` にあるため、既定の `.ec-auth.io` だけでは通りません。`docker-compose.yml` と `.github/workflows/playwright.yml` に `ECAUTH_ALLOWED_HOSTS=.ec-auth.io,.azurewebsites.net` を配線済みです。
- 既にインストール済みの環境で許可外の Base URL が保存されている場合、実行時の再検証でログインできなくなります。その場合は `ECAUTH_ALLOWED_HOSTS` に該当ホストを追加してください。

## テスト

- [x] `vendor/bin/phpunit` — **40 tests, 75 assertions OK**
  - 署名改竄 / 別鍵署名（kid 偽装）/ `alg: none` / HS256 alg confusion / `iss` 不一致 / `aud` 不一致 / `exp` 欠落 / 期限切れ / 未来の `nbf`・`iat` / `sub` 欠落 をすべて拒否
  - 許可リスト: apex 非一致、`evil-ec-auth.io` のような部分一致の拒否、ポート一致、認証情報付き URL の拒否 など
- [x] `vendor/bin/php-cs-fixer fix --dry-run` — 0 files
- [x] `vendor/bin/rector process --dry-run` — OK
- [x] `vendor/bin/phpstan analyse --level 6`（新規 4 ファイル）— No errors
- [x] 実 EcAuth (dev) の JWKS の鍵で PEM 組み立てを検証 — 2048bit RSA、modulus / exponent が完全一致
- [ ] E2E (Playwright) — 本 PR の CI で確認

E2E には `#101:` で始まる回帰テスト（許可外ホストの Base URL が保存できないこと）を追加しました。

## 関連

- EcAuthDocs #101
- 2 系（ec-cube2-ecauth）にも同一ロジックを展開予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * EcAuth の接続先 URL に許可ホストを設定できるようになりました。
  * URLの形式・スキーム・ポートを検証し、正規化します。
  * JWKS（公開鍵）をキャッシュして認証処理を効率化しました。
  * IDトークンの署名、発行元、対象者、有効期限などを検証します。

* **不具合修正**
  * 許可されていないURLや不正な形式のURLを保存できないようにしました。
  * 設定エラーがある場合、詳細設定を自動的に展開します。

* **テスト**
  * PHP 7.4／8.3環境での自動テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->