### PR TITLE
chore(release): v1.0.3 のバージョン更新とパッケージング修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
           rm -f "$GITHUB_WORKSPACE/pnpm-workspace.yaml"
           rm -f "$GITHUB_WORKSPACE/playwright.config.ts"
           rm -f "$GITHUB_WORKSPACE/phpstan.neon.dist"
+          rm -f "$GITHUB_WORKSPACE/phpunit.xml.dist"
           rm -f "$GITHUB_WORKSPACE/rector.php"
           rm -f "$GITHUB_WORKSPACE/.php-cs-fixer.dist.php"
           # 1Password テンプレートは秘密値こそ含まないが、Vault / アイテム名が

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --
 
 # バージョンを固定する場合（非秘密なのでインラインで渡す）
 # 値は検証したいバージョンに読み替える。省略すると最新が入る
-ECAUTH_PLUGIN_VERSION=1.0.2 \
+ECAUTH_PLUGIN_VERSION=1.0.3 \
   op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/ecauthlogin43",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "EC-CUBE 4.2/4.3系向け EcAuth 認証プラグイン",
   "type": "eccube-plugin",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION
## 概要

v1.0.3 のリリース準備です。`composer.json` の `version` を 1.0.2 → 1.0.3 に更新します。

## パッケージング修正 ⚠️

**#49 で PHPUnit を導入した際に追加した `phpunit.xml.dist` が `deploy.yml` の除外リストに入っておらず、v1.0.3 の配布物に初めて混入する状態でした。** v1.0.2 で `Tests/` と `.env*.tpl` を除外したのと同じ種類の漏れです。

`phpstan.neon.dist` 等と同様に除外します。`Tests/` 配下（テスト本体・`rector.php`・`.php-cs-fixer.dist.php`）はディレクトリごと削除されるため影響はありません。

### ローカル検証

`deploy.yml` のパッケージング処理を手元で再現しました。

**修正前**（`phpunit.xml.dist` が混入）
```
Controller  Entity  Form  Repository  Resource  Service
EcAuthLoginEvent.php  EcAuthLoginNav.php  PluginManager.php
LICENSE  README.md  composer.json  phpunit.xml.dist   ← ✗
```

**修正後**
```
Controller  Entity  Form  Repository  Resource  Service
EcAuthLoginEvent.php  EcAuthLoginNav.php  PluginManager.php
LICENSE  README.md  composer.json
```

`*.dist` / `*.spec.ts` / `rector.php` / `.env*` の残存が無いことも確認済みです。

## その他

- `CLAUDE.md` の package-api 検証手順のバージョン例を 1.0.3 に更新

## リリース手順

本 PR マージ後、タグ `1.0.3`（`v` プレフィックス無し、既存タグに合わせる）で GitHub Release を publish します。`deploy.yml` が `release: published` を受けて tar.gz を生成し、リリースアセットとして添付します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)