### PR TITLE
ci: E2E 実行前に staging EcAuth をウォームアップする

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -95,6 +95,35 @@ jobs:
             exit 1
           fi
 
+      - name: Warm up staging EcAuth
+        # staging の App Service は Free tier のため alwaysOn を有効化できず、
+        # 一定時間アイドルだとワーカーがアンロードされる。コールドスタート中は
+        # HTTP が遅いだけでなく TCP 接続自体が失敗しうる（実際に E2E が
+        # cURL error 7 / 28 で落ちた）。Playwright を走らせる前に暖めておく。
+        #
+        # ここで落ちた場合は「staging が応答しない」ことが明確になり、
+        # プラグイン側の不具合と切り分けられる。
+        env:
+          ECAUTH_BASE_URL: https://ecauth-staging-${{ env.STAGING_WEB_APP_SUFFIX }}.azurewebsites.net
+        run: |
+          ready=false
+          for i in $(seq 1 10); do
+            # 接続失敗時も curl は -w で 000 を出力するため、ここで既定値を足すと
+            # 000000 のように連結されてしまう。curl の出力をそのまま使う。
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 30 "${ECAUTH_BASE_URL}/healthz" || true)
+            if [ "${code:-000}" = "200" ]; then
+              echo "staging EcAuth is warm (attempt $i)"
+              ready=true
+              break
+            fi
+            echo "Waiting for staging EcAuth... ($i/10, http=${code:-000})"
+            sleep 5
+          done
+          if [ "$ready" != "true" ]; then
+            echo "::error::staging EcAuth did not become reachable; E2E cannot run" >&2
+            exit 1
+          fi
+
       - name: Run Playwright tests
         run: pnpm exec playwright test --reporter=list
         env:


### PR DESCRIPTION
## 背景

staging の EcAuth は App Service の **Free tier** で稼働しており、`alwaysOn` を有効化できません（Free では設定不可）。そのため一定時間アイドルだとワーカーがアンロードされ、次のリクエストでコールドスタートが発生します。

コールドスタート中は HTTP が遅いだけでなく **TCP 接続自体が失敗しうる** ため、E2E が実際に 2 回落ちました（いずれも再実行で成功）。

```
cURL error 7: Failed to connect to ecauth-staging-***.azurewebsites.net port 443 after 17025 ms
cURL error 28: Connection timed out after 30002 milliseconds
```

失敗するのは staging への HTTP 呼び出しに依存するテスト（パスキー一覧・登録・ログイン）だけで、切り分けにアプリログの確認が必要でした。

## 変更内容

Playwright 実行の直前に `/healthz` が 200 を返すまで待つステップを追加します。

- 最大 10 回・1 回あたり 30 秒でリトライ（最悪 5 分程度で打ち切り）
- 200 が返れば即座に次へ進むため、暖まっている通常時のオーバーヘッドはほぼゼロ
- 到達しなければ `::error::` を出して**このステップで失敗**する

最後の点が実質的な価値です。**「staging が応答しない」ことが明確になり、プラグイン側の不具合と切り分けられます。**これまでは E2E の不可解な失敗として現れていました。

## 検証

スクリプトをローカルで実行しました。

```
# 正常時（staging 稼働中）
staging EcAuth is warm (attempt 1)        → exit 0

# 到達不能時（存在しないホストで確認）
Waiting for staging EcAuth... (1/2, http=000)
Waiting for staging EcAuth... (2/2, http=000)
::error::staging EcAuth did not become reachable; E2E cannot run   → exit 1
```

検証中に、`curl ... || echo 000` としていると接続失敗時に `http=000000` と表示される問題を見つけて修正しました（curl は `-w` で既に `000` を出力するため二重になっていた）。

## 補足

**恒久対策としては App Service を B1 以上にするのが確実です**（`alwaysOn` が有効化でき、Free tier の 1 日 60 分 CPU クォータもなくなります）。本 PR はコストをかけずに CI の安定性を上げる対症療法です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)