### PR TITLE
chore: Dependabot の依存更新を group 化

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,103 @@
 version: 2
+
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "weekly"
+  # GitHub Actions の自動更新
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # minor/patch と major の 2 PR に集約する。
+    # patterns を "*" にしているのは、サードパーティ actions
+    # （anthropics/* 1password/* shivammathur/* softprops/* pnpm/* 等）を
+    # 取りこぼさないため。
+    groups:
+      github-actions-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      github-actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  # Composer パッケージの自動更新
+  # require は PSR インタフェースと ec-cube/plugin-installer のみ、
+  # require-dev は静的解析・テストツール（phpstan / rector / php-cs-fixer /
+  # phpunit）。いずれも major 更新の影響は CI（composer phpstan / rector /
+  # cs-check）が検出できるため minor/patch と major の 2 PR に集約する。
+  #
+  # 注意: このプラグインは PHP 7.4 互換を維持する必要がある
+  # （CLAUDE.md「コーディング規約」参照）。major 更新 PR をマージする前に
+  # rector.php の phpVersion 固定と .php-cs-fixer.dist.php の設定が
+  # 引き続き 7.4 互換を保っているか確認すること。
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "composer"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    allow:
+      - dependency-type: "all"
+    groups:
+      composer-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      composer-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+
+  # npm パッケージの自動更新
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "npm"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    allow:
+      - dependency-type: "all"
+    groups:
+      npm-minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"


### PR DESCRIPTION
## 背景

EcAuth 系 10 リポジトリで Dependabot 設定を統一する取り組みの一環。

このリポジトリの dependabot.yml は `package-ecosystem` と `schedule.interval` だけの最小構成で、group / labels / commit-message が無かった。現時点でオープンな Dependabot PR は 0 件だが、他リポジトリと同じ設定に揃えておく。

## 変更内容

### 1. group を minor/patch と major の 2 本に集約

npm / composer / github-actions の各エコシステムに追加。`patterns: ["*"]` を使い、必ずどちらかの group に入るようにした。

このリポジトリのワークフローは `anthropics/*` `1password/*` `shivammathur/*` `softprops/*` `pnpm/*` といったサードパーティ actions が大半を占めるため、ベンダー別 patterns では取りこぼす。

### 2. 他リポジトリと設定を統一

- **schedule** — 曜日・時刻・タイムゾーン（Asia/Tokyo 09:00）を指定。actions=月 / composer=火 / npm=水 で負荷を分散
- **labels** — `dependencies` + エコシステム名
- **commit-message** — `prefix: chore` / `include: scope`（Conventional Commits 形式に統一）

## composer の major 更新についての注意

require は PSR インタフェースと `ec-cube/plugin-installer` のみ、require-dev は静的解析・テストツール（phpstan / rector / php-cs-fixer / phpunit）で、major の影響は CI（`composer phpstan` / `rector` / `cs-check`）が検出できるため group にまとめている。

ただし**本プラグインは PHP 7.4 互換を維持する必要がある**（CLAUDE.md「コーディング規約」）。major 更新 PR をマージする前に、`Tests/rector.php` の `phpVersion` 固定と `Tests/.php-cs-fixer.dist.php` の `trailing_comma_in_multiline` 設定が引き続き 7.4 互換を保っているか確認すること。この注意書きは設定ファイルのコメントにも残した。

## 検証

- [x] YAML パース（`yaml.safe_load`）
- [x] `composer.json` / `package.json` の実在を確認
- [x] 行末空白なし / LF 改行
- [ ] **Dependabot 設定の妥当性はサーバー側でしか検証できない**（未検証）。マージ後に Insights → Dependency graph → Dependabot でエラーが出ていないことを確認する

## 関連

EcAuth 系 10 リポジトリ横断で同じテンプレートを適用する PR の 1 本。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 依存関係と開発ツールの更新を、より計画的かつ定期的に実施できるよう運用を改善しました。
  * 更新内容を種類ごとに整理し、確認しやすくしました。
  * これにより、セキュリティや互換性に関わる更新を継続的に取り込みやすくなります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->