### PR TITLE
fix: 別テナント切替時のパスキー登録失敗と、無言で終わる認証を直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,6 +210,54 @@ ec-cube4-ecauth/
   - `bin/console debug:container --env-vars` で env 使用箇所を一覧できる
   - env 未設定時のフォールバック値がコードではなく config に集約される
 
+## EcAuth 連携で踏みやすい罠
+
+### ecauth_subject は接続先テナント（client_id）を変えたらクリアが要る
+
+`PasskeyAuthService::ensureB2BUser()` は `b2b_subject` を `dtb_member.ecauth_subject` に
+永続化し、値があれば**無条件に再利用**する。一方 EcAuth 側の `B2BUser.Subject` は
+Organization をまたいでグローバル一意なので、**テスト用テナントの `client_id` で試した後に
+本番用へ差し替えると、別 Organization に同じ subject を登録しようとして必ず失敗する**
+（`register/options` が 400、EcAuth 側ログに `Failed to create or retrieve B2BUser: <uuid>`）。
+
+`reconcileEcauthSubjectFromOptions()` は救ってくれない。あれは `register/options` が 200 を
+返した後の突き合わせなので、400 で弾かれるこのケースでは呼ばれる前に return する。
+
+そのため `ConfigController::index()` が保存前後の `client_id` を比較し、変わっていれば
+`PasskeyAuthService::clearAllEcauthSubjects()` で一括クリアする（#52）。テナントを移す以上、
+旧 subject に紐づくパスキーはどのみち使えないため実害はない。設定画面は送信前に
+`confirm()` を挟むが、**確認はあくまで UI 上の保険**で、クリアの判断はサーバー側の
+新旧比較が行う（`curl` 等 JS を経由しない送信でも整合する）。
+
+`dtb_customer` 側は触らない。あちらは B2C の `sub` で、発番するのはプラグインではなく
+EcAuth 側であり、テナントが変われば別の値が降ってきて衝突しないため。
+
+判定条件（初回登録・同値・空白差ではクリアしない等）は EC-CUBE 非依存の
+`Service/TenantChangePolicy` に切り出してある。`phpunit.xml.dist` は EC-CUBE のカーネルを
+起動しないため、コントローラやサービスに直接書くとユニットテストで固定できない。
+
+### フォームは「管理対象エンティティ」に直接バインドされる
+
+`ConfigController` は `configRepository->get()` が返す managed entity をそのまま
+`createForm()` に渡す。したがって **`handleRequest()` を通した時点で `$Config` の値は
+入力値で上書きされている**。「保存前の値」と比較したい場合は `handleRequest()` より前に
+退避しておくこと。2 系（配列で設定を持つ）から移植するときに最も間違えやすい点。
+
+なお `flush()` を呼ばずに return する経路では、managed entity を書き換えていても
+永続化されない（`TransactionListener` は commit するだけで flush はしない）。
+バリデーションエラーで抜ける経路が副作用を残さないのはこのため。
+
+`update_date` は EC-CUBE 本体の `SaveEventSubscriber::preUpdate()` が自動更新するので
+明示設定は不要。ただし**これは UnitOfWork 経由のときだけ効く**。DQL の bulk UPDATE で
+書き換えると発火しないので、件数が小さいならエンティティを load して書き換える。
+
+### form_widget の attr に id を渡しても上書きされない
+
+`{{ form_widget(form.foo, { attr: { id: 'my-id' } }) }}` と書くと、Symfony が出力する
+`id="form_foo"` は消えず **`id` 属性が 2 つ並ぶ**。HTML パーサは先勝ちなので後ろは無視され、
+`getElementById('my-id')` は `null` を返す（JS が静かに何もしなくなる）。
+テンプレート側から要素を掴むときは `{{ form.foo.vars.id }}` で本来の id を引くこと。
+
 ## セキュリティ注意事項
 
 - client_secret はサーバーサイドのみ。JS に渡さない

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -7,9 +7,13 @@ use Plugin\EcAuthLogin43\Form\Type\Admin\ConfigType;
 use Plugin\EcAuthLogin43\Repository\ConfigRepository;
 use Plugin\EcAuthLogin43\Service\BaseUrlValidator;
 use Plugin\EcAuthLogin43\Service\ClientResolveService;
+use Plugin\EcAuthLogin43\Service\PasskeyAuthService;
+use Plugin\EcAuthLogin43\Service\TenantChangePolicy;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
@@ -29,6 +33,16 @@ class ConfigController extends AbstractController
      * @var BaseUrlValidator
      */
     protected $baseUrlValidator;
+
+    /**
+     * @var TenantChangePolicy
+     */
+    protected $tenantChangePolicy;
+
+    /**
+     * @var PasskeyAuthService
+     */
+    protected $passkeyAuthService;
 
     /**
      * @var TranslatorInterface
@@ -55,6 +69,8 @@ class ConfigController extends AbstractController
         ConfigRepository $configRepository,
         ClientResolveService $clientResolveService,
         BaseUrlValidator $baseUrlValidator,
+        TenantChangePolicy $tenantChangePolicy,
+        PasskeyAuthService $passkeyAuthService,
         TranslatorInterface $translator,
         string $signupUrl,
         string $mypageUrl
@@ -62,6 +78,8 @@ class ConfigController extends AbstractController
         $this->configRepository = $configRepository;
         $this->clientResolveService = $clientResolveService;
         $this->baseUrlValidator = $baseUrlValidator;
+        $this->tenantChangePolicy = $tenantChangePolicy;
+        $this->passkeyAuthService = $passkeyAuthService;
         $this->translator = $translator;
         $this->signupUrl = $signupUrl;
         $this->mypageUrl = $mypageUrl;
@@ -82,13 +100,44 @@ class ConfigController extends AbstractController
         $Config = $this->configRepository->get();
         $hasClientSecret = $Config && $Config->getClientSecret() !== null && $Config->getClientSecret() !== '';
 
+        // フォームは configRepository が返した「管理対象エンティティ」に直接バインドされる。
+        // handleRequest() を通した時点で $Config の値は入力値で上書きされてしまうため、
+        // 新旧比較に使う値はここで退避しておく必要がある（#52）。
+        $previousClientId = $Config !== null ? (string) $Config->getClientId() : '';
+        $savedBaseUrl = $Config !== null ? (string) $Config->getEcauthBaseUrl() : '';
+
         $form = $this->createForm(ConfigType::class, $Config);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
             $Config = $form->getData();
 
+            // 接続先テナントの差し替えかどうか。判定はサーバー側のこの比較が行う。
+            // 設定画面の confirm() は UI 上の保険にすぎず、JS を経由しない送信でも整合する。
+            $clientIdChanged = $this->tenantChangePolicy->hasClientIdChanged(
+                $previousClientId,
+                $Config->getClientId(),
+            );
+
+            $clientSecret = $form->get('client_secret')->getData();
+
+            // 接続先が変わるのに Client Secret が空だと、前のテナントの secret が
+            // 残ったまま新しい client_id と組み合わさる。トークン交換もパスキー登録も
+            // 通らない設定が「保存成功」として残り、原因が分かりにくいので保存前に弾く。
+            if ($clientIdChanged && ($clientSecret === null || $clientSecret === '')) {
+                $form->get('client_secret')->addError(
+                    new FormError($this->translator->trans('ecauth_login43.admin.config.tenant_changed.secret_required')),
+                );
+
+                return $this->createViewParameters($form, $hasClientSecret, $previousClientId);
+            }
+
             $inputUrl = trim((string) $Config->getEcauthBaseUrl());
+            if ($this->tenantChangePolicy->shouldDiscardBaseUrlInput($clientIdChanged, $inputUrl, $savedBaseUrl)) {
+                // 事前入力のまま＝前の接続先の URL。捨てて新しい client_id から解決し直す。
+                $inputUrl = '';
+            }
+
             if ($inputUrl === '') {
                 $resolved = $this->clientResolveService->resolve((string) $Config->getClientId());
                 if (!$resolved['success']) {
@@ -96,12 +145,7 @@ class ConfigController extends AbstractController
                         new FormError($this->translator->trans('ecauth_login43.admin.config.client_resolve.failed')),
                     );
 
-                    return [
-                        'form' => $form->createView(),
-                        'has_client_secret' => $hasClientSecret,
-                        'signup_url' => $this->signupUrl,
-                        'mypage_url' => $this->mypageUrl,
-                    ];
+                    return $this->createViewParameters($form, $hasClientSecret, $previousClientId);
                 }
                 $candidateUrl = $resolved['base_url'];
                 // client-resolve 応答も無条件には信頼しない。応答が汚染されると
@@ -118,33 +162,77 @@ class ConfigController extends AbstractController
                     new FormError($this->translator->trans('ecauth_login43.admin.config.base_url.not_allowed')),
                 );
 
-                return [
-                    'form' => $form->createView(),
-                    'has_client_secret' => $hasClientSecret,
-                    'signup_url' => $this->signupUrl,
-                    'mypage_url' => $this->mypageUrl,
-                ];
+                return $this->createViewParameters($form, $hasClientSecret, $previousClientId);
             }
 
             $Config->setEcauthBaseUrl($normalizedUrl);
 
-            $clientSecret = $form->get('client_secret')->getData();
             if ($clientSecret !== null && $clientSecret !== '') {
                 $Config->setClientSecret($clientSecret);
             }
+
+            // 旧テナントで発番した subject のクリアは、設定の保存と同じ flush に載せる。
+            // 「subject だけ消えて client_id は元のまま」のような中途半端な状態を
+            // 作らないため（EC-CUBE 本体の TransactionListener がリクエスト全体を
+            // 1 トランザクションに包むので、commit も一括で行われる）。
+            $cleared = $clientIdChanged ? $this->passkeyAuthService->clearAllEcauthSubjects() : 0;
+
             $this->entityManager->persist($Config);
             $this->entityManager->flush();
 
             $this->addSuccess('ecauth_login43.admin.config.save.success', 'admin');
 
+            if ($clientIdChanged) {
+                $this->onTenantChanged($request->getSession(), $cleared);
+            }
+
             return $this->redirectToRoute('ecauth_login43_admin_config');
         }
 
+        return $this->createViewParameters($form, $hasClientSecret, $previousClientId);
+    }
+
+    /**
+     * 接続先テナント（client_id）を差し替えた後の後始末。
+     *
+     * ecauth_subject のクリアは flush 済みの前提でここに来る。
+     *
+     * @param int $cleared クリアした ecauth_subject の件数
+     */
+    protected function onTenantChanged(SessionInterface $session, int $cleared): void
+    {
+        // 旧テナントで取得した access_token / credential_id / 進行中の session_id は
+        // もう通用しない。残すとパスキー管理画面が不可解なエラーで一覧取得に失敗する。
+        // _security_admin は触らない（管理者を保存操作の途中でログアウトさせないため）。
+        $session->remove('ecauth_access_token');
+        $session->remove('ecauth_current_credential_id');
+        $session->remove('ecauth_register_session_id');
+        $session->remove('ecauth_passkey_session_id');
+        $session->remove('ecauth_state');
+        $session->remove('ecauth_code_verifier');
+
+        // 管理画面のフラッシュは alert.twig が {{ message|trans }} で描画するだけで
+        // パラメータを渡せないため、件数の差し込みはここで済ませてから渡す。
+        $message = $cleared === 0
+            ? $this->translator->trans('ecauth_login43.admin.config.tenant_changed.no_target')
+            : $this->translator->trans('ecauth_login43.admin.config.tenant_changed.cleared', ['%count%' => $cleared]);
+
+        $this->addWarning($message, 'admin');
+    }
+
+    /**
+     * @param string $savedClientId 保存済みの client_id（テンプレートの確認ダイアログ判定に使う）
+     *
+     * @return array<string, mixed>
+     */
+    protected function createViewParameters(FormInterface $form, bool $hasClientSecret, string $savedClientId): array
+    {
         return [
             'form' => $form->createView(),
             'has_client_secret' => $hasClientSecret,
             'signup_url' => $this->signupUrl,
             'mypage_url' => $this->mypageUrl,
+            'saved_client_id' => $savedClientId,
         ];
     }
 }

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -133,24 +133,40 @@ class ConfigController extends AbstractController
             }
 
             $inputUrl = trim((string) $Config->getEcauthBaseUrl());
+            $discardedBaseUrl = '';
             if ($this->tenantChangePolicy->shouldDiscardBaseUrlInput($clientIdChanged, $inputUrl, $savedBaseUrl)) {
                 // 事前入力のまま＝前の接続先の URL。捨てて新しい client_id から解決し直す。
+                // ただし解決に失敗したときのために、捨てた値は候補として持っておく。
+                $discardedBaseUrl = $inputUrl;
                 $inputUrl = '';
             }
 
+            $reusedBaseUrl = null;
             if ($inputUrl === '') {
                 $resolved = $this->clientResolveService->resolve((string) $Config->getClientId());
-                if (!$resolved['success']) {
+                if ($resolved['success']) {
+                    $candidateUrl = $resolved['base_url'];
+                    // client-resolve 応答も無条件には信頼しない。応答が汚染されると
+                    // トークン交換先ごと攻撃者のホストに向く（EcAuthDocs #101）。
+                    $errorField = 'client_id';
+                } elseif ($discardedBaseUrl !== '') {
+                    // 解決できないなら、採れる候補は捨てた入力しか無い。ここで弾くと
+                    // 「同じ EcAuth を複数テナントで共有し、URL を手動指定している」
+                    // staging / 開発環境で接続先を切り替えられなくなる。しかも
+                    // client_resolve.failed は「高度な設定で URL を直接指定してください」と
+                    // 案内するのに、その値を捨てた結果のエラーなので、指示どおり同じ値を
+                    // 入れ直しても同じところに戻ってきてしまう（#59 レビュー指摘）。
+                    // 黙って引き継ぐのではなく、下の警告で管理者に確認を促す。
+                    $candidateUrl = $discardedBaseUrl;
+                    $errorField = 'ecauth_base_url';
+                    $reusedBaseUrl = $discardedBaseUrl;
+                } else {
                     $form->get('client_id')->addError(
                         new FormError($this->translator->trans('ecauth_login43.admin.config.client_resolve.failed')),
                     );
 
                     return $this->createViewParameters($form, $hasClientSecret, $previousClientId);
                 }
-                $candidateUrl = $resolved['base_url'];
-                // client-resolve 応答も無条件には信頼しない。応答が汚染されると
-                // トークン交換先ごと攻撃者のホストに向く（EcAuthDocs #101）。
-                $errorField = 'client_id';
             } else {
                 $candidateUrl = $inputUrl;
                 $errorField = 'ecauth_base_url';
@@ -183,7 +199,13 @@ class ConfigController extends AbstractController
             $this->addSuccess('ecauth_login43.admin.config.save.success', 'admin');
 
             if ($clientIdChanged) {
-                $this->onTenantChanged($request->getSession(), $cleared);
+                // 引き継いだ URL は保存されたもの（正規化後）を出す。入力の表記ゆれを
+                // そのまま見せると、実際に保存された値と食い違って確認の役に立たない。
+                $this->onTenantChanged(
+                    $request->getSession(),
+                    $cleared,
+                    $reusedBaseUrl === null ? null : $normalizedUrl,
+                );
             }
 
             return $this->redirectToRoute('ecauth_login43_admin_config');
@@ -198,8 +220,10 @@ class ConfigController extends AbstractController
      * ecauth_subject のクリアは flush 済みの前提でここに来る。
      *
      * @param int $cleared クリアした ecauth_subject の件数
+     * @param string|null $reusedBaseUrl client_id から解決できず、前の接続先の URL を
+     *                                   そのまま引き継いだ場合はその URL。通常は null
      */
-    protected function onTenantChanged(SessionInterface $session, int $cleared): void
+    protected function onTenantChanged(SessionInterface $session, int $cleared, ?string $reusedBaseUrl = null): void
     {
         // 旧テナントで取得した access_token / credential_id / 進行中の session_id は
         // もう通用しない。残すとパスキー管理画面が不可解なエラーで一覧取得に失敗する。
@@ -218,6 +242,16 @@ class ConfigController extends AbstractController
             : $this->translator->trans('ecauth_login43.admin.config.tenant_changed.cleared', ['%count%' => $cleared]);
 
         $this->addWarning($message, 'admin');
+
+        if ($reusedBaseUrl !== null) {
+            $this->addWarning(
+                $this->translator->trans(
+                    'ecauth_login43.admin.config.tenant_changed.base_url_reused',
+                    ['%url%' => $reusedBaseUrl],
+                ),
+                'admin',
+            );
+        }
     }
 
     /**

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -26,6 +26,7 @@ ecauth_login43.admin.config.tenant_changed.confirm: Client ID を変更しよう
 ecauth_login43.admin.config.tenant_changed.secret_required: Client ID を変更する場合は、新しい接続先の Client Secret も入力してください。前の接続先の Client Secret は使用できません。
 ecauth_login43.admin.config.tenant_changed.cleared: 接続先のテナントが変わったため、登録済みのパスキー %count% 件分の紐付けを解除しました。パスキー管理から登録し直してください。
 ecauth_login43.admin.config.tenant_changed.no_target: 接続先のテナントが変わりました。
+ecauth_login43.admin.config.tenant_changed.base_url_reused: 新しい Client ID から EcAuth URL を解決できなかったため、これまでの EcAuth URL (%url%) をそのまま使用します。接続先が正しいか確認してください。
 ecauth_login43.admin.config.base_url.not_allowed: EcAuth URL が許可されていないホストを指しています。https で始まる正しい EcAuth の URL を指定してください。開発・ステージング環境のホストを使う場合は、環境変数 ECAUTH_ALLOWED_HOSTS に追加してください。
 ecauth_login43.admin.config.required: 必須
 ecauth_login43.admin.config.save: 登録

--- a/Resource/locale/messages.ja.yaml
+++ b/Resource/locale/messages.ja.yaml
@@ -21,6 +21,11 @@ ecauth_login43.admin.config.rp_id.help: 未設定の場合、サイトのホス�
 ecauth_login43.admin.config.advanced_settings: 高度な設定
 ecauth_login43.admin.config.advanced_settings.help: 通常は変更不要です。ステージング・開発環境や RP ID のカスタマイズが必要な場合のみ使用してください。
 ecauth_login43.admin.config.client_resolve.failed: Client ID に対応するテナントが見つかりませんでした。Client ID を確認するか、高度な設定で EcAuth URL を直接指定してください。
+ecauth_login43.admin.config.tenant_changed.caution: Client ID を変更すると接続先のテナントが変わります。登録済みのパスキーはすべて使えなくなり、パスキー管理から登録し直しが必要になります。
+ecauth_login43.admin.config.tenant_changed.confirm: Client ID を変更しようとしています。接続先のテナントが変わるため、登録済みのパスキーはすべて使えなくなり、パスキー管理からの登録し直しが必要になります。よろしいですか？
+ecauth_login43.admin.config.tenant_changed.secret_required: Client ID を変更する場合は、新しい接続先の Client Secret も入力してください。前の接続先の Client Secret は使用できません。
+ecauth_login43.admin.config.tenant_changed.cleared: 接続先のテナントが変わったため、登録済みのパスキー %count% 件分の紐付けを解除しました。パスキー管理から登録し直してください。
+ecauth_login43.admin.config.tenant_changed.no_target: 接続先のテナントが変わりました。
 ecauth_login43.admin.config.base_url.not_allowed: EcAuth URL が許可されていないホストを指しています。https で始まる正しい EcAuth の URL を指定してください。開発・ステージング環境のホストを使う場合は、環境変数 ECAUTH_ALLOWED_HOSTS に追加してください。
 ecauth_login43.admin.config.required: 必須
 ecauth_login43.admin.config.save: 登録
@@ -63,6 +68,10 @@ ecauth_login43.admin.passkey.current: ログイン中
 # ログイン画面
 ecauth_login43.admin.login.passkey_button: パスキーでログイン
 ecauth_login43.admin.login.passkey.error: パスキー認証に失敗しました。
+# NotAllowedError は「利用者がキャンセルした」場合と「該当するパスキーが端末に無い」
+# 場合の両方で発生し、ブラウザ API 上は区別できない。双方に当てはまる文面にする（#58）。
+ecauth_login43.admin.login.passkey.not_found: パスキーが見つからないか、認証がキャンセルされました。
+ecauth_login43.admin.login.passkey.hint: このアカウントで初めてパスキーを使う場合は、パスワードでログインしてから「設定 → EcAuth → パスキー管理」でパスキーを登録してください。
 ecauth_login43.admin.login.passkey.not_supported: お使いのブラウザはパスキー認証に対応していません。
 ecauth_login43.admin.login.passkey.https_required: パスキー認証にはHTTPS接続が必要です。
 

--- a/Resource/template/admin/config.twig
+++ b/Resource/template/admin/config.twig
@@ -59,8 +59,12 @@
                                     <span class="badge badge-primary ms-1">{{ 'ecauth_login43.admin.config.required'|trans }}</span>
                                 </div>
                                 <div class="col">
-                                    {{ form_widget(form.client_id) }}
+                                    {# attr に id を渡しても Symfony が出力する id="config_client_id" が消えず
+                                       id 属性が 2 つ並ぶ（HTML パーサは先勝ちなので後ろは無視される）。
+                                       JS 側は form.client_id.vars.id で本来の id を引く。 #}
+                                    {{ form_widget(form.client_id, { attr: { 'data-saved': saved_client_id } }) }}
                                     {{ form_errors(form.client_id) }}
+                                    <p class="form-text text-muted" id="ecauth-client-id-caution">{{ 'ecauth_login43.admin.config.tenant_changed.caution'|trans }}</p>
                                 </div>
                             </div>
                             <div class="row mb-2">
@@ -152,4 +156,37 @@
             </div>
         </div>
     </form>
+{% endblock %}
+
+{% block javascript %}
+    <script>
+        // Client ID を書き換えたまま保存しようとしたら確認する。
+        //
+        // これは UI 上の保険にすぎない。実際に ecauth_subject をクリアするかどうかは
+        // ConfigController が保存前後の client_id を比較して決めるので、JS を経由しない
+        // 送信（curl 等）でもサーバー側の判断と食い違わない。
+        document.addEventListener('DOMContentLoaded', function () {
+            var input = document.getElementById('{{ form.client_id.vars.id }}');
+            if (!input || !input.form) {
+                return;
+            }
+
+            var CONFIRM_MESSAGE = '{{ 'ecauth_login43.admin.config.tenant_changed.confirm'|trans|e('js') }}';
+
+            input.form.addEventListener('submit', function (event) {
+                var saved = (input.getAttribute('data-saved') || '').trim();
+                var current = input.value.trim();
+
+                // 初回登録（保存済みが空）と、変更なしのときは確認しない。
+                // 判定条件は TenantChangePolicy::hasClientIdChanged() と揃えてある。
+                if (saved === '' || saved === current) {
+                    return;
+                }
+
+                if (!window.confirm(CONFIRM_MESSAGE)) {
+                    event.preventDefault();
+                }
+            });
+        });
+    </script>
 {% endblock %}

--- a/Resource/template/admin/login_passkey.twig
+++ b/Resource/template/admin/login_passkey.twig
@@ -16,12 +16,24 @@ document.addEventListener('DOMContentLoaded', function() {
         return;
     }
 
+    // 文言は JS 文字列に埋めるため e('js') でエスケープする。
+    // Twig の自動エスケープは HTML 向けで、引用符が実体参照になるだけなので
+    // JS リテラル内では正しく閉じられない値を作りうる。
+    var BUTTON_LABEL = '{{ "ecauth_login43.admin.login.passkey_button"|trans|e('js') }}';
+    var ERROR_MESSAGE = '{{ "ecauth_login43.admin.login.passkey.error"|trans|e('js') }}';
+    var NOT_FOUND_MESSAGE = '{{ "ecauth_login43.admin.login.passkey.not_found"|trans|e('js') }}';
+    // 初回利用者向けの常設案内。ログイン画面は EC-CUBE 本体のテンプレートなので、
+    // 案内文の要素を差し込むと本体の変更に追従しづらい。ボタンの title
+    // （ツールチップ）なら本体の DOM 構造に手を入れずに常時見せられる。
+    var HINT_MESSAGE = '{{ "ecauth_login43.admin.login.passkey.hint"|trans|e('js') }}';
+
     // パスキーログインボタンを作成
     var passkeyBtn = document.createElement('button');
     passkeyBtn.type = 'button';
     passkeyBtn.id = 'ecauth-passkey-login';
     passkeyBtn.className = 'btn btn-ec-regular btn-block mt-3';
-    passkeyBtn.textContent = '{{ "ecauth_login43.admin.login.passkey_button"|trans }}';
+    passkeyBtn.textContent = BUTTON_LABEL;
+    passkeyBtn.title = HINT_MESSAGE;
 
     // ボタンを追加
     submitButton.parentNode.insertBefore(passkeyBtn, submitButton.nextSibling);
@@ -42,16 +54,25 @@ document.addEventListener('DOMContentLoaded', function() {
                 window.location.href = result.redirect_url;
             } else {
                 passkeyBtn.disabled = false;
-                passkeyBtn.textContent = '{{ "ecauth_login43.admin.login.passkey_button"|trans }}';
-                alert('{{ "ecauth_login43.admin.login.passkey.error"|trans }}');
+                passkeyBtn.textContent = BUTTON_LABEL;
+                alert(ERROR_MESSAGE);
             }
         }).catch(function(error) {
             passkeyBtn.disabled = false;
-            passkeyBtn.textContent = '{{ "ecauth_login43.admin.login.passkey_button"|trans }}';
-            if (error.name !== 'NotAllowedError') {
-                console.error('Passkey authentication error:', error);
-                alert('{{ "ecauth_login43.admin.login.passkey.error"|trans }}');
+            passkeyBtn.textContent = BUTTON_LABEL;
+            // NotAllowedError はキャンセルだけでなく「該当するパスキーが端末に無い」
+            // ときにも出る。ログイン画面は誰がログインするか未確定なので b2b_subject を
+            // 送らず、EcAuth は組織内の全クレデンシャルを allowCredentials に詰めて返す。
+            // そのためパスキー未登録の管理者が押すと、他人のパスキーだけが許可された
+            // 状態で credentials.get() が呼ばれて必ずここへ来る。以前は握り潰していた
+            // ため「押しても何も起きない」ように見えていた（#58）。
+            if (error && error.name === 'NotAllowedError') {
+                alert(NOT_FOUND_MESSAGE + '\n\n' + HINT_MESSAGE);
+
+                return;
             }
+            console.error('Passkey authentication error:', error);
+            alert(ERROR_MESSAGE);
         });
     });
 });

--- a/Service/PasskeyAuthService.php
+++ b/Service/PasskeyAuthService.php
@@ -101,6 +101,48 @@ class PasskeyAuthService
     }
 
     /**
+     * 全 Member の ecauth_subject をクリアする。
+     *
+     * 接続先テナント（client_id）を差し替えたときに使う。ecauth_subject は EcAuth 側の
+     * B2BUser.Subject と 1:1 で、EcAuth では Subject が Organization をまたいで
+     * グローバル一意なため、旧テナントで発番済みの subject を残したまま client_id を
+     * 変えると、新テナントへの登録が一意制約に阻まれ register/options が必ず 400 に
+     * なる（#52）。クリアすれば次回登録時に新しい UUID が発番され、正常に登録できる。
+     * テナントを移す以上、旧 subject に紐づくパスキーはどのみち使えないため実害はない。
+     *
+     * 対象は dtb_member（B2B パスキー）のみ。dtb_customer 側の sub を発番するのは
+     * プラグインではなく EcAuth であり、テナントが変われば別の値が降ってきて
+     * 衝突しないため触らない。
+     *
+     * bulk UPDATE (DQL) ではなくエンティティを load して null を代入するのは、
+     * EC-CUBE 本体の SaveEventSubscriber::preUpdate() による update_date の自動更新が
+     * UnitOfWork を経由しないと効かないため。管理者数は現実的に小さいので問題ない。
+     *
+     * flush() は呼ばない。呼び出し側の 1 回の flush で Config の保存と同一
+     * トランザクションに載せ、「subject だけ消えて client_id は元のまま」といった
+     * 中途半端な状態を作らないため。
+     *
+     * @return int クリア対象になった件数
+     */
+    public function clearAllEcauthSubjects(): int
+    {
+        $Members = $this->memberRepository->createQueryBuilder('m')
+            ->where('m.ecauth_subject IS NOT NULL')
+            ->getQuery()
+            ->getResult();
+
+        foreach ($Members as $Member) {
+            $Member->setEcauthSubject(null);
+        }
+
+        $this->logger->info('Cleared ecauth_subject for tenant switch', [
+            'member_count' => count($Members),
+        ]);
+
+        return count($Members);
+    }
+
+    /**
      * コールバック処理: state検証 → トークン交換 → Member検索 → セッション確立
      *
      * @param string $code 認可コード

--- a/Service/TenantChangePolicy.php
+++ b/Service/TenantChangePolicy.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Service;
+
+/**
+ * 設定画面で接続先テナント（client_id）が差し替えられたかを判定し、
+ * それに伴う入力値の扱いを決める。
+ *
+ * EcAuth の B2BUser.Subject は Organization をまたいでグローバル一意なため、
+ * 旧テナントで発番済みの ecauth_subject を残したまま client_id を差し替えると、
+ * 新テナントへの登録が一意制約に阻まれ register/options が必ず 400 になる
+ * （EcAuth/ec-cube4-ecauth#52）。その後始末を起動するかどうかの判断がここ。
+ *
+ * EC-CUBE / Symfony に依存しない純粋な判定のみを置く。判定の分岐が多く、
+ * 誤ると「全管理者のパスキーを巻き添えでクリアする」方向に倒れるため、
+ * ユニットテスト（Tests/Unit/TenantChangePolicyTest.php）で固定している。
+ * EC-CUBE のカーネルを起動しない phpunit.xml.dist の対象に入れるための分離でもある。
+ */
+class TenantChangePolicy
+{
+    /**
+     * 接続先テナント（client_id）が変わったかを判定する。
+     *
+     * - 初回登録（保存前の値が無い）では変更扱いにしない。まだどのテナントにも
+     *   subject を登録していないため、後始末する対象が存在しない。
+     * - 前後が同じなら変更ではない。設定画面は client_id 以外（rp_id 等）だけを
+     *   変えて保存されることの方が多く、ここで誤判定すると全管理者の
+     *   パスキーを巻き添えにする。
+     * - 前後の空白差だけの違いも変更としない。保存側は trim 済みの値を渡すが、
+     *   旧値は trim せず保存された可能性があるため、両方 trim して比べる。
+     * - client_id は EcAuth が払い出す不透明な識別子なので、大文字小文字は区別する。
+     */
+    public function hasClientIdChanged(?string $previousClientId, ?string $newClientId): bool
+    {
+        $previous = trim((string) $previousClientId);
+        $new = trim((string) $newClientId);
+
+        if ($previous === '') {
+            return false;
+        }
+
+        return $previous !== $new;
+    }
+
+    /**
+     * 接続先が変わるとき、フォームの Base URL 入力を捨てて再解決すべきかを判定する。
+     *
+     * 設定画面は Base URL 欄に保存済みの値を事前入力する。Client ID だけを
+     * 書き換えて保存すると、欄に残った「前の接続先の URL」が入力値として扱われ、
+     * 新しい client_id と前のテナントの Base URL という不整合な組み合わせが
+     * 保存されてしまう。事前入力のまま（＝保存済みと同値）なら触っていないと
+     * みなして捨て、client_id からの再解決に委ねる。
+     *
+     * 逆に保存済みと違う値が入っていれば管理者が意図して指定したものなので
+     * 尊重する（開発・ステージングの手動指定を潰さないため）。
+     */
+    public function shouldDiscardBaseUrlInput(bool $clientIdChanged, ?string $inputBaseUrl, ?string $savedBaseUrl): bool
+    {
+        if (!$clientIdChanged) {
+            return false;
+        }
+
+        $input = trim((string) $inputBaseUrl);
+        if ($input === '') {
+            // もともと未入力なら呼び出し側が従来どおり再解決する。捨てるものが無い。
+            return false;
+        }
+
+        return $input === trim((string) $savedBaseUrl);
+    }
+}

--- a/Service/TenantChangePolicy.php
+++ b/Service/TenantChangePolicy.php
@@ -53,6 +53,12 @@ class TenantChangePolicy
      *
      * 逆に保存済みと違う値が入っていれば管理者が意図して指定したものなので
      * 尊重する（開発・ステージングの手動指定を潰さないため）。
+     *
+     * ここで true を返しても「その URL を使わない」とは限らない。呼び出し側は
+     * 再解決に失敗したときに捨てた値へフォールバックする。同じ EcAuth を複数
+     * テナントで共有し URL を手動指定している環境では、捨てたまま弾くと接続先を
+     * 切り替える手段が無くなるため（#59 レビュー指摘）。あくまで
+     * 「解決できるなら新しい client_id 由来の URL を優先する」という優先順位付け。
      */
     public function shouldDiscardBaseUrlInput(bool $clientIdChanged, ?string $inputBaseUrl, ?string $savedBaseUrl): bool
     {

--- a/Tests/Unit/TenantChangePolicyTest.php
+++ b/Tests/Unit/TenantChangePolicyTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Plugin\EcAuthLogin43\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Plugin\EcAuthLogin43\Service\TenantChangePolicy;
+
+/**
+ * EcAuth/ec-cube4-ecauth#52: 接続先テナント（client_id）を差し替えたのに
+ * dtb_member.ecauth_subject が残っていると、EcAuth 側の B2BUser.Subject が
+ * Organization をまたいでグローバル一意なせいで register/options が必ず 400 になる。
+ *
+ * 誤って「変更あり」と判定すると全管理者のパスキーを巻き添えでクリアするため、
+ * 判定の分岐をここで固定する。
+ */
+class TenantChangePolicyTest extends TestCase
+{
+    /**
+     * @var TenantChangePolicy
+     */
+    private $policy;
+
+    protected function setUp(): void
+    {
+        $this->policy = new TenantChangePolicy();
+    }
+
+    // ------------------------------------------------------------------
+    // いつ「接続先が変わった」とみなすか
+    // ------------------------------------------------------------------
+
+    public function testInitialSaveIsNotTreatedAsChange(): void
+    {
+        // 初回登録。まだどのテナントにも subject を登録していないので後始末は不要。
+        self::assertFalse($this->policy->hasClientIdChanged('', 'ec-shop-1111'));
+        self::assertFalse($this->policy->hasClientIdChanged(null, 'ec-shop-1111'));
+    }
+
+    public function testUnchangedClientIdIsNotAChange(): void
+    {
+        // client_id 以外（rp_id 等）だけを変えて保存する方が普通の操作なので、
+        // ここで誤判定すると全管理者のパスキーを巻き添えにする。
+        self::assertFalse($this->policy->hasClientIdChanged('ec-shop-1111', 'ec-shop-1111'));
+    }
+
+    public function testWhitespaceOnlyDifferenceIsNotAChange(): void
+    {
+        // 保存側は trim 済みの値を渡すが、旧値は trim せず保存された可能性がある。
+        // 空白差だけで全管理者のパスキーを無効化してはいけない。
+        self::assertFalse($this->policy->hasClientIdChanged(' ec-shop-1111 ', 'ec-shop-1111'));
+        self::assertFalse($this->policy->hasClientIdChanged('ec-shop-1111', "ec-shop-1111\n"));
+    }
+
+    public function testDifferentClientIdIsAChange(): void
+    {
+        // #52 の本題。テスト用テナントから本番用テナントへの差し替え。
+        self::assertTrue($this->policy->hasClientIdChanged('ec-shop-1111', 'ec-shop-2222'));
+    }
+
+    public function testClientIdIsComparedCaseSensitively(): void
+    {
+        // client_id は EcAuth が払い出す不透明な識別子。大文字小文字が違えば別テナント。
+        self::assertTrue($this->policy->hasClientIdChanged('ec-shop-1111', 'EC-SHOP-1111'));
+    }
+
+    public function testBlankedOutClientIdIsAChange(): void
+    {
+        // ConfigType の NotBlank があるため通常は起きないが、
+        // 接続先が失われた状態で古い subject を残す理由も無い。
+        self::assertTrue($this->policy->hasClientIdChanged('ec-shop-1111', ''));
+        self::assertTrue($this->policy->hasClientIdChanged('ec-shop-1111', null));
+    }
+
+    // ------------------------------------------------------------------
+    // 接続先が変わるとき、事前入力の Base URL を捨てるか
+    //
+    // 設定画面は Base URL 欄に保存済みの値を事前入力する。Client ID だけを
+    // 書き換えて保存すると、欄に残った前の接続先の URL が「入力あり」と見なされ、
+    // 「新しい client_id + 前の接続先の Base URL」が保存されてしまう。
+    // ------------------------------------------------------------------
+
+    public function testBaseUrlInputIsKeptWhenClientIdUnchanged(): void
+    {
+        // Client ID が同じなら、Base URL 欄の値は管理者の意思として尊重する。
+        self::assertFalse($this->policy->shouldDiscardBaseUrlInput(
+            false,
+            'https://old.ec-auth.io',
+            'https://old.ec-auth.io',
+        ));
+    }
+
+    public function testUntouchedBaseUrlIsDiscardedWhenClientIdChanged(): void
+    {
+        // 事前入力のまま（保存済みの値と同一）＝ 触っていないので捨てて再解決する。
+        self::assertTrue($this->policy->shouldDiscardBaseUrlInput(
+            true,
+            'https://old.ec-auth.io',
+            'https://old.ec-auth.io',
+        ));
+        // 前後の空白差は「触った」うちに入らない。
+        self::assertTrue($this->policy->shouldDiscardBaseUrlInput(
+            true,
+            ' https://old.ec-auth.io ',
+            'https://old.ec-auth.io',
+        ));
+    }
+
+    public function testExplicitlyTypedBaseUrlIsKeptWhenClientIdChanged(): void
+    {
+        // 保存済みと違う値を打っているなら、管理者が意図して指定したもの。
+        // 開発・ステージングの手動指定を潰さないため、こちらは尊重する。
+        self::assertFalse($this->policy->shouldDiscardBaseUrlInput(
+            true,
+            'https://new.ec-auth.io',
+            'https://old.ec-auth.io',
+        ));
+    }
+
+    public function testEmptyBaseUrlInputIsNotTreatedAsDiscardable(): void
+    {
+        // もともと未入力なら呼び出し側が従来どおり解決する。捨てるものが無い。
+        self::assertFalse($this->policy->shouldDiscardBaseUrlInput(true, '', 'https://old.ec-auth.io'));
+        self::assertFalse($this->policy->shouldDiscardBaseUrlInput(true, null, null));
+    }
+
+    public function testFirstTimeSaveWithTypedBaseUrlIsKept(): void
+    {
+        // 初回登録は hasClientIdChanged() が false になるため、
+        // 保存済みが空でも入力値は捨てられない。
+        self::assertFalse($this->policy->shouldDiscardBaseUrlInput(false, 'https://new.ec-auth.io', ''));
+    }
+}

--- a/Tests/specs/passkey_auth.spec.ts
+++ b/Tests/specs/passkey_auth.spec.ts
@@ -21,6 +21,17 @@ test.describe('パスキーログインフロー', () => {
     await expect(passkeyBtn).toHaveText(/パスキーでログイン/);
   });
 
+  // #58: パスキー未登録の管理者に手がかりを残すため、ボタン自体に常設の案内を出す。
+  // ログイン画面は EC-CUBE 本体のテンプレートなので、案内文の要素を差し込むと
+  // 本体の変更に追従しづらい。title（ツールチップ）なら DOM 構造に手を入れずに済む。
+  test('#58: パスキーボタンに初回利用者向けの案内が title で表示される', async ({ page }) => {
+    await page.goto(`${ADMIN_URL}/login`);
+
+    const passkeyBtn = page.locator('#ecauth-passkey-login');
+    await expect(passkeyBtn).toHaveAttribute('title', /パスワードでログイン/);
+    await expect(passkeyBtn).toHaveAttribute('title', /パスキー管理/);
+  });
+
   test('パスキーボタンクリックで認証フローが開始される', async ({ page, context }) => {
     // Virtual Authenticator を設定
     const cdpSession = await context.newCDPSession(page);
@@ -372,6 +383,97 @@ test.describe.serial('E2E: パスキー登録からログイン完了までの�
     await page.goto(`${ADMIN_URL}/`);
     await expect(page).toHaveURL(/\/admin\/?$/);
     await expect(page.locator('h2', { hasText: 'ホーム' })).toBeVisible();
+  });
+
+  // リグレッション (#58): パスキー未登録の管理者が「パスキーでログイン」を押したとき、
+  // 案内ダイアログが出ること。
+  //
+  // ログイン画面は誰がログインするか未確定なので b2b_subject を送らず、EcAuth は
+  // Organization 内の全クレデンシャルを allowCredentials に詰めて返す。そのため
+  // パスキー未登録の管理者が押すと「他人のパスキーだけが許可された」状態で
+  // credentials.get() が呼ばれ NotAllowedError になる。以前はこれを無条件に
+  // 握り潰していたため、ボタンのラベルが戻るだけで何も起きなかった。
+  //
+  // 「サーバーには登録済み・この端末には無い」状態を作るため、資格情報を持たない
+  // 仮想オーセンティケータを載せた別 context で検証する。共有 page の
+  // WebAuthn.clearCredentials で作らないのは、/admin/login がログイン済みだと
+  // リダイレクトされてボタンに到達できないため。後続の一覧テストが使う
+  // セッションとパスキーには一切触れない。
+  test('#58: パスキー未登録の端末で押すと案内ダイアログが表示される', async ({ browser }) => {
+    // options 取得は staging EcAuth 往復で、credentials.get のタイムアウトも
+    // サーバー由来 (既定 60s) になりうるため、通常より長めに取る。
+    test.setTimeout(120000);
+
+    const freshContext = await browser.newContext({ ignoreHTTPSErrors: true });
+    // EcAuth が timeout=0 を返すケースに備える (共有 context と同じ理由)
+    await freshContext.addInitScript(() => {
+      const originalGet = navigator.credentials.get.bind(navigator.credentials);
+      navigator.credentials.get = async (options?: CredentialRequestOptions) => {
+        if (options?.publicKey && (!options.publicKey.timeout || options.publicKey.timeout === 0)) {
+          options.publicKey.timeout = 60000;
+        }
+
+        return originalGet(options);
+      };
+    });
+
+    const freshPage = await freshContext.newPage();
+    let freshCdp: CDPSession | undefined;
+    let freshAuthenticatorId: string | undefined;
+
+    try {
+      await freshPage.goto(`${ADMIN_URL}/login`);
+      await freshPage.waitForLoadState('domcontentloaded');
+
+      freshCdp = await freshContext.newCDPSession(freshPage);
+      await freshCdp.send('WebAuthn.enable');
+      const created = await freshCdp.send('WebAuthn.addVirtualAuthenticator', {
+        options: {
+          protocol: 'ctap2',
+          transport: 'internal',
+          hasResidentKey: true,
+          hasUserVerification: true,
+          isUserVerified: true,
+          automaticPresenceSimulation: true,
+        },
+      });
+      freshAuthenticatorId = created.authenticatorId;
+
+      // この認証器には資格情報を登録しない (= 端末側にパスキーが無い状態)
+      const { credentials } = await freshCdp.send('WebAuthn.getCredentials', {
+        authenticatorId: freshAuthenticatorId,
+      });
+      expect(credentials).toEqual([]);
+
+      const dialogs: string[] = [];
+      freshPage.on('dialog', async (dialog) => {
+        dialogs.push(dialog.message());
+        await dialog.accept().catch(() => {});
+      });
+
+      const passkeyBtn = freshPage.locator('#ecauth-passkey-login');
+      await expect(passkeyBtn).toBeVisible();
+      await passkeyBtn.click();
+
+      // 無言で終わらないこと。文面はキャンセルと「該当パスキー無し」の両方に
+      // 当てはまるものにしたうえで、次に何をすればよいかを併記する。
+      await expect.poll(() => dialogs.length, { timeout: 75000 }).toBeGreaterThan(0);
+      expect(dialogs[0]).toContain('パスキーが見つからないか');
+      expect(dialogs[0]).toContain('パスワードでログイン');
+
+      // ボタンが押せる状態に戻り、ログイン画面から離脱していないこと
+      await expect(passkeyBtn).toBeEnabled();
+      await expect(passkeyBtn).toHaveText('パスキーでログイン');
+      await expect(freshPage).toHaveURL(/\/admin\/login/);
+    } finally {
+      if (freshCdp && freshAuthenticatorId) {
+        await freshCdp
+          .send('WebAuthn.removeVirtualAuthenticator', { authenticatorId: freshAuthenticatorId })
+          .catch(() => {});
+      }
+      await freshCdp?.detach().catch(() => {});
+      await freshContext.close().catch(() => {});
+    }
   });
 
   // パスキーログイン直後 (session に access_token / current_credential_id が

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
 const ADMIN_URL = '/admin';
 const LOGIN_ID = process.env.ADMIN_LOGIN_ID || 'admin';
@@ -16,8 +16,32 @@ const MYPAGE_URL = process.env.ECAUTH_MYPAGE_URL || 'https://ec-auth.io/mypage/'
 // 保存できない（EcAuthDocs #101）。保存できる例として ec-auth.io のサブドメインを使う。
 const ALLOWED_BASE_URL = 'https://e2e-tenant.ec-auth.io';
 
+/**
+ * ダイアログのメッセージを収集しつつ、指定どおり accept / dismiss する。
+ * リスナー未登録だと Playwright が自動で dismiss してしまい、
+ * 「確認が出たか」と「何と出たか」を区別できない。
+ */
+const captureDialogs = (page: Page, action: 'accept' | 'dismiss'): string[] => {
+  const messages: string[] = [];
+  page.on('dialog', async (dialog) => {
+    messages.push(dialog.message());
+    if (action === 'accept') {
+      await dialog.accept().catch(() => {});
+    } else {
+      await dialog.dismiss().catch(() => {});
+    }
+  });
+
+  return messages;
+};
+
 test.describe('プラグイン設定画面', () => {
   test.beforeEach(async ({ page }) => {
+    // #52 で Client ID の変更時に confirm() を挟むようにしたため、保存を伴うテストは
+    // 直前の DB 状態次第で確認ダイアログに当たる。ハンドラを置かないと Playwright が
+    // 自動 dismiss して送信自体が止まり、実行順や前回の残骸で結果が変わってしまう。
+    captureDialogs(page, 'accept');
+
     // 管理画面ログイン
     await page.goto(`${ADMIN_URL}/login`);
     await page.fill('input[name="login_id"]', LOGIN_ID);
@@ -123,5 +147,148 @@ test.describe('プラグイン設定画面', () => {
     await expect(page.locator('input[name="config[ecauth_base_url]"]')).not.toHaveValue(
       'https://auth.example.com',
     );
+  });
+});
+
+/**
+ * #52: 接続先テナント (client_id) を差し替えたときの扱い。
+ *
+ * EcAuth の B2BUser.Subject は Organization をまたいでグローバル一意なため、
+ * 旧テナントで発番済みの dtb_member.ecauth_subject を残したまま client_id を
+ * 差し替えると、新テナントへの登録が一意制約に阻まれ register/options が必ず
+ * 400 になる。設定画面がその後始末（subject のクリア）を担う。
+ *
+ * ecauth_subject の中身は管理画面から見えないため、ここでは「後始末が起動した
+ * こと」を警告フラッシュで検証する。どういう条件で起動するかの分岐そのものは
+ * Tests/Unit/TenantChangePolicyTest.php が網羅している。
+ *
+ * 本 describe は設定を書き換えるので、他 spec に影響しないよう
+ * ファイル順で最後になる plugin_config.spec.ts の末尾に置く。
+ */
+test.describe.serial('#52: 接続先テナントの切り替え', () => {
+  const CLIENT_ID_INPUT = 'input[name="config[client_id]"]';
+  const TENANT_A = 'ecauth-e2e-tenant-a';
+  const TENANT_B = 'ecauth-e2e-tenant-b';
+  const TENANT_A_URL = 'https://e2e-tenant-a.ec-auth.io';
+  const TENANT_B_URL = 'https://e2e-tenant-b.ec-auth.io';
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto(`${ADMIN_URL}/login`);
+    await page.fill('input[name="login_id"]', LOGIN_ID);
+    await page.fill('input[name="password"]', PASSWORD);
+    await page.click('button[type="submit"]');
+    await page.waitForURL(`**${ADMIN_URL}/**`);
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+  });
+
+  // 先行 describe が別の client_id を保存しているため、この保存自体がテナント変更に
+  // なりうる（＝警告が出ることもある）。ここは以降のテストの基準点を作るのが目的なので
+  // 警告の有無は問わない。「変更していないのに警告が出ない」ことは末尾のテストで見る。
+  test('前提: テナント A の接続設定を保存する', async ({ page }) => {
+    captureDialogs(page, 'accept');
+
+    await page.fill(CLIENT_ID_INPUT, TENANT_A);
+    await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-a');
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
+    await page.fill('input[name="config[ecauth_base_url]"]', TENANT_A_URL);
+
+    await page.click('button[type="submit"]');
+    await expect(page.locator('.alert-success')).toBeVisible();
+
+    // 保存済み値がテンプレートに載り、次回以降の比較対象になる
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveAttribute('data-saved', TENANT_A);
+  });
+
+  test('Client ID を変更して送信すると確認ダイアログが出る（キャンセルすれば保存されない）', async ({ page }) => {
+    const dialogs = captureDialogs(page, 'dismiss');
+
+    await page.fill(CLIENT_ID_INPUT, TENANT_B);
+    await page.click('button[type="submit"]');
+
+    await expect.poll(() => dialogs.length, { timeout: 5000 }).toBeGreaterThan(0);
+    expect(dialogs[0]).toContain('接続先のテナントが変わる');
+
+    // キャンセルしたので送信されない
+    await expect(page.locator('.alert-success')).toHaveCount(0);
+
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_A);
+  });
+
+  test('Client ID 変更時に Client Secret が空なら保存できない', async ({ page }) => {
+    // 空のまま通すと「新しい client_id + 前のテナントの client_secret」という
+    // どこにも通らない組み合わせが保存成功として残ってしまう。
+    captureDialogs(page, 'accept');
+
+    await page.fill(CLIENT_ID_INPUT, TENANT_B);
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator('text=新しい接続先の Client Secret も入力してください')).toBeVisible();
+    await expect(page.locator('.alert-success')).toHaveCount(0);
+
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_A);
+  });
+
+  test('Client ID 変更時は事前入力の Base URL を引き継がず再解決する', async ({ page }) => {
+    // client-resolve は実ネットワークを叩くため、失敗時のタイムアウトを見込む
+    test.setTimeout(90000);
+    captureDialogs(page, 'accept');
+
+    // Base URL 欄には保存済みの値（テナント A の URL）が事前入力されている。
+    // ここを触らずに Client ID だけ変えるのが #52 の再現操作。
+    await page.fill(CLIENT_ID_INPUT, TENANT_B);
+    await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-b');
+    await page.click('button[type="submit"]');
+
+    // 事前入力を捨てて client_id から解決し直すため、解決に失敗して弾かれる。
+    // 引き継いでいたら「テナント A の URL」で保存が通ってしまう。
+    await expect(page.locator('text=Client ID に対応するテナントが見つかりませんでした')).toBeVisible();
+    await expect(page.locator('.alert-success')).toHaveCount(0);
+
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_A);
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(TENANT_A_URL);
+  });
+
+  test('Client ID を変更して保存すると、パスキー紐付け解除の警告が出る', async ({ page }) => {
+    captureDialogs(page, 'accept');
+
+    await page.fill(CLIENT_ID_INPUT, TENANT_B);
+    await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-b');
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
+    await page.fill('input[name="config[ecauth_base_url]"]', TENANT_B_URL);
+
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator('.alert-success')).toBeVisible();
+    // 対象 0 件なら「接続先のテナントが変わりました。」、1 件以上なら
+    // 「接続先のテナントが変わったため、…紐付けを解除しました。」。
+    // 先行 spec がパスキーを登録しているかで件数が変わるため共通部分で見る。
+    await expect(page.locator('.alert-warning')).toContainText('接続先のテナントが変わ');
+
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_B);
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(TENANT_B_URL);
+  });
+
+  test('Client ID を変えずに保存したときは確認も警告も出ない', async ({ page }) => {
+    // rp_id だけ変えて保存するような通常の操作で全管理者のパスキーを
+    // 巻き添えにしないことの確認。
+    const dialogs = captureDialogs(page, 'accept');
+
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
+    await page.fill('input[name="config[rp_id]"]', 'localhost');
+
+    await page.click('button[type="submit"]');
+
+    await expect(page.locator('.alert-success')).toBeVisible();
+    await expect(page.locator('.alert-warning')).toHaveCount(0);
+    expect(dialogs).toHaveLength(0);
   });
 });

--- a/Tests/specs/plugin_config.spec.ts
+++ b/Tests/specs/plugin_config.spec.ts
@@ -167,10 +167,14 @@ test.describe('プラグイン設定画面', () => {
  */
 test.describe.serial('#52: 接続先テナントの切り替え', () => {
   const CLIENT_ID_INPUT = 'input[name="config[client_id]"]';
+  // serial なので、各 test は「直前の test が保存した状態」から始まる。
+  // client_id を A → B → C と一方向に進めることで、どの test でも
+  // 「保存済みと違う値を入れる＝テナント変更」が成立するようにしている。
   const TENANT_A = 'ecauth-e2e-tenant-a';
   const TENANT_B = 'ecauth-e2e-tenant-b';
+  const TENANT_C = 'ecauth-e2e-tenant-c';
   const TENANT_A_URL = 'https://e2e-tenant-a.ec-auth.io';
-  const TENANT_B_URL = 'https://e2e-tenant-b.ec-auth.io';
+  const TENANT_C_URL = 'https://e2e-tenant-c.ec-auth.io';
 
   test.beforeEach(async ({ page }) => {
     await page.goto(`${ADMIN_URL}/login`);
@@ -231,7 +235,13 @@ test.describe.serial('#52: 接続先テナントの切り替え', () => {
     await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_A);
   });
 
-  test('Client ID 変更時は事前入力の Base URL を引き継がず再解決する', async ({ page }) => {
+  // 事前入力の Base URL は「まず捨てて client_id から解決し直す」が、解決できなければ
+  // 捨てた値に戻す。ここで弾いてしまうと、同じ EcAuth を複数テナントで共有し URL を
+  // 手動指定している staging / 開発環境で接続先を切り替える手段が無くなる（#59 レビュー指摘）。
+  //
+  // 引き継いだこと自体は警告で可視化する。この警告が出ること＝「入力を鵜呑みにせず
+  // 再解決を試みたうえで諦めた」ことの証拠になる（鵜呑みなら警告は出ない）。
+  test('Client ID 変更時に再解決できなければ、既存の Base URL を引き継いで警告する', async ({ page }) => {
     // client-resolve は実ネットワークを叩くため、失敗時のタイムアウトを見込む
     test.setTimeout(90000);
     captureDialogs(page, 'accept');
@@ -242,13 +252,40 @@ test.describe.serial('#52: 接続先テナントの切り替え', () => {
     await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-b');
     await page.click('button[type="submit"]');
 
-    // 事前入力を捨てて client_id から解決し直すため、解決に失敗して弾かれる。
-    // 引き継いでいたら「テナント A の URL」で保存が通ってしまう。
+    await expect(page.locator('.alert-success')).toBeVisible();
+    await expect(
+      page.locator('.alert-warning', { hasText: 'EcAuth URL を解決できなかったため' }),
+    ).toBeVisible();
+    // 行き止まりにしない。以前は client_resolve.failed で弾いており、しかもその文言は
+    // 「高度な設定で URL を直接指定してください」と、既に指定済みの操作を案内していた。
+    await expect(page.locator('text=Client ID に対応するテナントが見つかりませんでした')).toHaveCount(0);
+
+    await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_B);
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(TENANT_A_URL);
+  });
+
+  // 引き継ぎ先が無い（Base URL 未設定）ときは従来どおり弾く。他に採れる候補が無く、
+  // 解決できない client_id をそのまま保存しても動かないため。
+  test('Base URL 未設定で Client ID を解決できなければ保存できない', async ({ page }) => {
+    test.setTimeout(90000);
+    captureDialogs(page, 'accept');
+
+    await page.click(ADVANCED_TOGGLE);
+    await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
+    await page.fill('input[name="config[ecauth_base_url]"]', '');
+    await page.fill(CLIENT_ID_INPUT, TENANT_C);
+    await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-c');
+
+    await page.click('button[type="submit"]');
+
     await expect(page.locator('text=Client ID に対応するテナントが見つかりませんでした')).toBeVisible();
     await expect(page.locator('.alert-success')).toHaveCount(0);
 
+    // 弾かれた以上、副作用も残っていないこと
     await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
-    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_A);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_B);
     await page.click(ADVANCED_TOGGLE);
     await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(TENANT_A_URL);
   });
@@ -256,11 +293,11 @@ test.describe.serial('#52: 接続先テナントの切り替え', () => {
   test('Client ID を変更して保存すると、パスキー紐付け解除の警告が出る', async ({ page }) => {
     captureDialogs(page, 'accept');
 
-    await page.fill(CLIENT_ID_INPUT, TENANT_B);
-    await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-b');
+    await page.fill(CLIENT_ID_INPUT, TENANT_C);
+    await page.fill('input[name="config[client_secret]"]', 'secret-for-tenant-c');
     await page.click(ADVANCED_TOGGLE);
     await expect(page.locator(ADVANCED_PANEL)).toHaveClass(/show/);
-    await page.fill('input[name="config[ecauth_base_url]"]', TENANT_B_URL);
+    await page.fill('input[name="config[ecauth_base_url]"]', TENANT_C_URL);
 
     await page.click('button[type="submit"]');
 
@@ -268,12 +305,16 @@ test.describe.serial('#52: 接続先テナントの切り替え', () => {
     // 対象 0 件なら「接続先のテナントが変わりました。」、1 件以上なら
     // 「接続先のテナントが変わったため、…紐付けを解除しました。」。
     // 先行 spec がパスキーを登録しているかで件数が変わるため共通部分で見る。
-    await expect(page.locator('.alert-warning')).toContainText('接続先のテナントが変わ');
+    await expect(page.locator('.alert-warning', { hasText: '接続先のテナントが変わ' })).toBeVisible();
+    // URL は明示指定したので、引き継ぎの警告は出ない
+    await expect(
+      page.locator('.alert-warning', { hasText: 'EcAuth URL を解決できなかったため' }),
+    ).toHaveCount(0);
 
     await page.goto(`${ADMIN_URL}/ecauth_login43/config`);
-    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_B);
+    await expect(page.locator(CLIENT_ID_INPUT)).toHaveValue(TENANT_C);
     await page.click(ADVANCED_TOGGLE);
-    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(TENANT_B_URL);
+    await expect(page.locator('input[name="config[ecauth_base_url]"]')).toHaveValue(TENANT_C_URL);
   });
 
   test('Client ID を変えずに保存したときは確認も警告も出ない', async ({ page }) => {


### PR DESCRIPTION
Closes #52
Closes #58

2 系（EcAuth/ec-cube2-ecauth#18 / #26、[PR #28](https://github.com/EcAuth/ec-cube2-ecauth/pull/28)）で本番に表面化した 2 件を 4 系へ横展開します。

## Summary

- **#52**: `client_id`（接続先テナント）を差し替えても `dtb_member.ecauth_subject` が再利用され、パスキー登録が必ず 400 になる問題を、設定保存時の一括クリアで解消
- **#58**: パスキー未登録の管理者がログインボタンを押しても何のフィードバックも出ない問題を、`NotAllowedError` 時の案内表示とボタンの `title` による常設案内で解消

## Changes

### #52 接続先テナントの切り替え

`ensureB2BUser()` は `ecauth_subject` に値があれば無条件に再利用しますが、EcAuth の `B2BUser.Subject` は Organization をまたいでグローバル一意です。そのため旧テナントの subject を残したまま `client_id` を差し替えると、新テナントへの登録が一意制約に阻まれ `register/options` が必ず 400 になります。`reconcileEcauthSubjectFromOptions()` は 200 の後にしか走らないため救いません。

- `Service/TenantChangePolicy`（新規）— 「接続先が変わったか」「事前入力の Base URL を捨てるか」の判定。EC-CUBE 非依存にして単体テスト可能にしています
- `PasskeyAuthService::clearAllEcauthSubjects()`（新規）— `dtb_member` のみ対象。`dtb_customer` 側の `sub` は EcAuth が発番しテナントが変われば別の値が降ってくるため触りません
- `ConfigController` — 旧値との比較、Client Secret の必須化、Base URL の再解決、セッション破棄、警告フラッシュ
- `config.twig` — 送信前の `confirm()` と常設の注意書き

`confirm()` は **UI 上の保険**にすぎず、クリアの判断はサーバー側の新旧比較が行います（`curl` 等 JS を経由しない送信でも整合します）。

Base URL は「事前入力のままなら捨てて `client_id` から解決し直す」が、**解決に失敗したときは捨てた値へフォールバック**します（[レビュー指摘](https://github.com/EcAuth/ec-cube4-ecauth/pull/59#discussion_r3742474770) 対応、`cb2e2ee`）。同じ EcAuth を複数テナントで共有し URL を手動指定している staging / 開発環境で、接続先を切り替える手段が無くなるためです。引き継いだことは警告で可視化します。Base URL 未設定で解決にも失敗する場合は、他に採れる候補が無いので従来どおり弾きます。

### 4 系固有の事情で 2 系と実装が変わった点

| | 2 系 | 4 系 |
|---|---|---|
| 旧 `client_id` の取得 | 保存直前に `getConfig()` で読める | フォームが managed entity に直接バインドされるため **`handleRequest()` より前に退避が必須** |
| クリアと保存の順序 | `SC_Query::error()` が `E_USER_ERROR` で即死しトランザクションを張れないため「クリアを先に」で担保 | Doctrine の `flush()` が 1 トランザクションなので **同じ flush に載せる**（2 系より強い保証） |
| `update_date` | `$arrRawSql` で明示更新 | 本体の `SaveEventSubscriber::preUpdate()` が自動更新。ただし UnitOfWork 経由でないと発火しないため、bulk UPDATE ではなくエンティティを load して代入 |

### #58 パスキー未登録時のフィードバック

ログイン画面は誰がログインするか未確定なので `b2b_subject` を送らず、EcAuth は Organization 内の全クレデンシャルを `allowCredentials` に詰めて返します。パスキー未登録の管理者が押すと「他人のパスキーだけが許可された」状態で `credentials.get()` が呼ばれ `NotAllowedError` になりますが、`catch` が無条件に握り潰していました。

- `NotAllowedError` でも案内を表示。キャンセルと「該当パスキー無し」はブラウザ API 上区別できないため、双方に当てはまる文面にしています
- 初回利用者向けの常設案内はボタンの `title`（ツールチップ）。ログイン画面は本体テンプレートなので、案内文の要素を差し込むと本体の変更に追従しづらいためです
- 併せて script 内の `|trans` 出力を `|e('js')` に統一しました（Twig の自動エスケープは HTML 向けで、引用符が実体参照になるだけなので JS リテラル内では閉じられません）

`allowCredentials` に全件入る点自体は未対応です。直すにはログイン画面で `b2b_subject` を送る必要があり、ログイン ID の入力 UI が要るため別途とします。

## Test plan

- [x] `Tests/Unit/TenantChangePolicyTest.php`（新規 11 tests）— クリア判定と Base URL 破棄判定の全分岐
- [x] `Tests/specs/plugin_config.spec.ts`（新規 7 tests）— 確認ダイアログ / Client Secret 必須 / 再解決できないときの Base URL 引き継ぎと警告 / 引き継ぎ先が無いときは従来どおり弾く / 紐付け解除の警告フラッシュ / 変更なし時に何も起きないこと
- [x] `Tests/specs/passkey_auth.spec.ts`（新規 2 tests）— `title` 属性（staging 不要）と、資格情報を持たない仮想オーセンティケータを載せた別 context での案内ダイアログ発火（staging 必要）
- [x] 既存の設定保存テストに dialog ハンドラを追加（#52 の `confirm()` は直前の DB 状態次第で出るため、未処理だと Playwright の自動 dismiss で送信が止まる）

### 実機検証（ローカル Docker）

- [x] `client_id` 変更時に `ecauth_subject` が NULL になり `update_date` が進む。同一 `client_id` では両方とも不変
- [x] JS を通さない `curl` 送信でも同じ判断になる
- [x] Client Secret 未入力の拒否が**副作用ゼロ**（`client_id` / secret / subject すべて不変）。`flush()` を呼ばない経路では managed entity の変更が永続化されないことの確認でもあります
- [x] 件数入りフラッシュが「登録済みのパスキー 1 件分の紐付けを解除しました」と描画される
- [x] ログイン画面の配信 HTML に `title` と `NotAllowedError` 分岐が乗り、注入後の JS に構文エラーが無い
- [x] 追加ユニットテストは 4 パターンの変異注入でいずれも検知する
- [x] レビュー指摘の状況（共有ホストを手動指定したまま解決不能な `client_id` へ切替）を Docker で再現し、保存成功・URL 引き継ぎ・`ecauth_subject` クリア・警告 2 件を確認
- [x] cs-check / Rector / PHPUnit (63 tests) pass、ローカル E2E 19 passed / 7 skipped
- [x] staging を要する E2E（#58 のダイアログ発火を含む 7 件）を CI で確認 — [run 31292023428](https://github.com/EcAuth/ec-cube4-ecauth/actions/runs/31292023428) で **26 passed / 0 skipped / retry なし**

## Notes

- バージョンは上げていません。このリポジトリではバージョン更新は専用の `release/*` PR（`chore(release):`）で行う運用のためです
- スキーマ変更・マイグレーションはありません

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 管理画面で Client ID 変更時の確認や、Client Secret 再入力を追加しました。
  * テナント変更時に、既存のパスキー認証情報とセッションを安全に解除します。
  * パスキー未登録・認証キャンセル時の案内を改善しました。
* **改善**
  * テナント変更時の Base URL 処理と警告表示を改善しました。
* **テスト**
  * テナント変更およびパスキー認証に関する検証を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

