### PR TITLE
chore(release): v1.0.4 のバージョン更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --
 
 # バージョンを固定する場合（非秘密なのでインラインで渡す）
 # 値は検証したいバージョンに読み替える。省略すると最新が入る
-ECAUTH_PLUGIN_VERSION=1.0.3 \
+ECAUTH_PLUGIN_VERSION=1.0.4 \
   op run --env-file=.env.tpl --env-file=.env.verify.tpl -- docker compose up -d --build
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ec-cube/ecauthlogin43",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "EC-CUBE 4.2/4.3系向け EcAuth 認証プラグイン",
   "type": "eccube-plugin",
   "license": "LGPL-2.1-or-later",


### PR DESCRIPTION
## Summary

v1.0.4 リリースに向けて `composer.json` の `version` を 1.0.3 → 1.0.4 に更新します。

## Changes

- `composer.json` — `version` を 1.0.4 に
- `CLAUDE.md` — package-api 検証手順のバージョン例を追従

パッケージング処理（`deploy.yml`）の変更は**不要**です。#59 で追加した `Service/TenantChangePolicy.php` は配布対象、`Tests/Unit/TenantChangePolicyTest.php` は `Tests/` ごと削除されるためです。

## Test plan

- [x] `deploy.yml` の Packaging ステップをローカルで再現し、配布物が**本番用 27 ファイルのみ**になることを確認
  - `Service/TenantChangePolicy.php` が含まれる
  - `Tests/` / `*.spec.ts` / `*Test.php` / `.env*.tpl` / `CLAUDE.md` / `docker*` / `*.dist*` の混入なし
  - `composer.json` の `version` が `1.0.4`

## 1.0.4 の内容（#59）

- **#52** `client_id`（接続先テナント）を差し替えても `dtb_member.ecauth_subject` が再利用され、パスキー登録が必ず 400 になる問題を修正
- **#58** パスキー未登録の管理者がログインボタンを押しても何のフィードバックも出ない問題を修正

🤖 Generated with [Claude Code](https://claude.com/claude-code)